### PR TITLE
Implement function calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Expression evaluator status:
 * [x] selector expressions
 * [x] case expressions
 * [ ] method call expressions
-* [ ] function call expressions (a temporary 'notice' implementation is present)
+* [x] function call expressions
+* [ ] lambdas (implemented except for parameter type checking)
 * [ ] catalog expressions
 * [ ] access expressions (implemented for all but Type and resource operands)
 * [x] global scope
@@ -52,10 +53,61 @@ Expression evaluator status:
 * [x] string interpolation
 * [ ] EPP support
 
-Compiler status:
+Puppet functions implemented:
+
+* [x] alert
+* [ ] assert_type
+* [ ] contain
+* [ ] create_resources
+* [x] crit
+* [x] debug
+* [ ] defined
+* [ ] digest
+* [ ] each
+* [x] emerg
+* [ ] epp
+* [x] err
+* [ ] extlookup
+* [x] fail
+* [ ] file
+* [ ] filter
+* [ ] fqdn_rand
+* [ ] generate
+* [ ] hiera
+* [ ] hiera_array
+* [ ] hiera_hash
+* [ ] hiera_include
+* [ ] include
+* [x] info
+* [ ] inline_epp
+* [ ] inline_template
+* [ ] lookup
+* [ ] map
+* [ ] match
+* [ ] md5
+* [x] notice
+* [ ] realize
+* [ ] reduce
+* [ ] regsubst
+* [ ] require
+* [ ] scanf
+* [ ] search
+* [ ] sha1
+* [ ] shellquote
+* [ ] slice
+* [ ] split
+* [ ] sprintf
+* [ ] tag
+* [ ] tagged
+* [ ] template
+* [ ] versioncmp
+* [x] warning
+* [x] with
+
+Catalog compiling status:
 
 * [ ] Node definition (fact gathering)
-* [ ] Catalog compilation from evaluation context
+* [ ] JSON catalog compilation from evaluation context
 
 The output of `puppetcpp` is currently the representation of the AST and its evaluation.
 Eventually it will output a JSON representation of a compiled catalog.

--- a/exe/main.cc
+++ b/exe/main.cc
@@ -33,7 +33,7 @@ int main(int argc, char* argv[])
 
         if (manifest.body()) {
             // Evaluate all expressions in the manifest's body
-            context ctx([&](token_position const& position, string const& message) {
+            context ctx(logger, [&](token_position const& position, string const& message) {
                 string text;
                 size_t column;
                 tie(text, column) = get_text_and_column(file, get<0>(position));
@@ -56,7 +56,7 @@ int main(int argc, char* argv[])
         tie(text, column) = get_text_and_column(file, get<0>(ex.position()));
         logger.log(level::error, get<1>(ex.position()), column, text, argv[1], ex.what());
     } catch (exception const& ex) {
-        logger.log(level::fatal, "unhandled exception: %1%", ex.what());
+        logger.log(level::critical, "unhandled exception: %1%", ex.what());
     }
 
     auto errors = logger.errors();

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -49,12 +49,16 @@ add_library(puppet SHARED
     src/ast/variable.cc
     src/logging/logger.cc
     src/parser/parser.cc
+    src/runtime/functions/fail.cc
+    src/runtime/functions/logging.cc
+    src/runtime/functions/with.cc
     src/runtime/context.cc
     src/runtime/expression_evaluator.cc
     src/runtime/operators.cc
     src/runtime/scope.cc
     src/runtime/string_interpolator.cc
     src/runtime/value.cc
+    src/runtime/yielder.cc
 )
 
 set_target_properties(puppet PROPERTIES VERSION "${LIBPUPPET_VERSION_MAJOR}.${LIBPUPPET_VERSION_MINOR}.${LIBPUPPET_VERSION_PATCH}" COTIRE_UNITY_LINK_LIBRARIES_INIT "COPY_UNITY")

--- a/lib/include/puppet/ast/access_expression.hpp
+++ b/lib/include/puppet/ast/access_expression.hpp
@@ -34,12 +34,6 @@ namespace puppet { namespace ast {
         std::vector<expression> const& arguments() const;
 
         /**
-         * Gets the argument expressions.
-         * @return Returns the argument expressions.
-         */
-        std::vector<expression>& arguments();
-
-        /**
          * Gets the position of the access.
          * @return Returns the position of the access.
          */
@@ -82,22 +76,10 @@ namespace puppet { namespace ast {
         primary_expression const& target() const;
 
         /**
-         * Gets the target expression.
-         * @return Returns the target expression.
-         */
-        primary_expression& target();
-
-        /**
          * Gets the accesses that make up the expression.
          * @return Returns the accesses in the expression.
          */
         std::vector<access> const& accesses() const;
-
-        /**
-         * Gets the accesses that make up the expression.
-         * @return Returns the accesses in the expression.
-         */
-        std::vector<access>& accesses();
 
         /**
          * Gets the position of the access expression.

--- a/lib/include/puppet/ast/array.hpp
+++ b/lib/include/puppet/ast/array.hpp
@@ -36,12 +36,6 @@ namespace puppet { namespace ast {
         boost::optional<std::vector<expression>> const& elements() const;
 
         /**
-         * Gets the optional elements of the array.
-         * @return Returns the optional elements of the array.
-         */
-        boost::optional<std::vector<expression>>& elements();
-
-        /**
          * Gets the position of the array.
          * @return Returns the position of the array.
          */

--- a/lib/include/puppet/ast/boolean.hpp
+++ b/lib/include/puppet/ast/boolean.hpp
@@ -34,12 +34,6 @@ namespace puppet { namespace ast {
         bool value() const;
 
         /**
-         * Gets the value of the boolean.
-         * @return Returns the value of the boolean.
-         */
-        bool& value();
-
-        /**
          * Gets the position of the boolean.
          * @return Returns the position of the boolean.
          */

--- a/lib/include/puppet/ast/case_expression.hpp
+++ b/lib/include/puppet/ast/case_expression.hpp
@@ -41,22 +41,10 @@ namespace puppet { namespace ast {
         std::vector<expression> const& options() const;
 
         /**
-         * Gets the case proposition options.
-         * @return Returns the case proposition options.
-         */
-        std::vector<expression>& options();
-
-        /**
          * Gets the expressions that make up the body of the proposition.
          * @return Returns the expressions that make up the body of the proposition.
          */
         boost::optional<std::vector<expression>> const& body() const;
-
-        /**
-         * Gets the expressions that make up the body of the proposition.
-         * @return Returns the expressions that make up the body of the proposition.
-         */
-        boost::optional<std::vector<expression>>& body();
 
         /**
          * Determines if the case proposition is the default case.
@@ -109,22 +97,10 @@ namespace puppet { namespace ast {
         ast::expression const& expression() const;
 
         /**
-         * Gets the case expression.
-         * @return Returns the case expression.
-         */
-        ast::expression& expression();
-
-        /**
          * Gets the case propositions.
          * @return Returns the case propositions.
          */
         std::vector<case_proposition> const& propositions() const;
-
-        /**
-         * Gets the case propositions.
-         * @return Returns the case propositions.
-         */
-        std::vector<case_proposition>& propositions();
 
         /**
          * Gets the position of the case expression.

--- a/lib/include/puppet/ast/class_definition_expression.hpp
+++ b/lib/include/puppet/ast/class_definition_expression.hpp
@@ -38,22 +38,10 @@ namespace puppet { namespace ast {
         ast::name const& name() const;
 
         /**
-         * Gets the name of the class.
-         * @return Returns the name of the class.
-         */
-        ast::name& name();
-
-        /**
          * Gets the class parameters.
          * @return Returns the class parameters.
          */
         boost::optional<std::vector<parameter>> const& parameters() const;
-
-        /**
-         * Gets the optional class parameters.
-         * @return Returns the optional class parameters.
-         */
-        boost::optional<std::vector<parameter>>& parameters();
 
         /**
          * Gets the optional parent name.
@@ -62,22 +50,10 @@ namespace puppet { namespace ast {
         boost::optional<ast::name> const& parent() const;
 
         /**
-         * Gets the optional parent name.
-         * @return Returns the optional parent name.
-         */
-        boost::optional<ast::name>& parent();
-
-        /**
          * Gets the optional body expressions.
          * @return Returns the optional body expressions.
          */
         boost::optional<std::vector<expression>> const& body() const;
-
-        /**
-         * Gets the optional body expressions.
-         * @return Returns the optional body expressions.
-         */
-        boost::optional<std::vector<expression>>& body();
 
         /**
          * Gets the position of the expression.

--- a/lib/include/puppet/ast/collection_expression.hpp
+++ b/lib/include/puppet/ast/collection_expression.hpp
@@ -64,34 +64,16 @@ namespace puppet { namespace ast {
         name const& attribute() const;
 
         /**
-         * Gets the attribute being queried.
-         * @return Returns the attribute being queried.
-         */
-        name& attribute();
-
-        /**
          * Gets the attribute query operator.
          * @return Returns the query operator.
          */
         attribute_query_operator op() const;
 
         /**
-         * Gets the attribute query operator.
-         * @return Returns the query operator.
-         */
-        attribute_query_operator& op();
-
-        /**
          * Gets the query value.
          * @return Returns the query value.
          */
         basic_expression const& value() const;
-
-        /**
-         * Gets the query value.
-         * @return Returns the query value.
-         */
-        basic_expression& value();
 
         /**
          * Gets the position of the query.
@@ -166,22 +148,10 @@ namespace puppet { namespace ast {
         binary_query_operator op() const;
 
         /**
-         * Gets the binary query operator in the expression.
-         * @return Returns the binary query operator in the expression.
-         */
-        binary_query_operator& op();
-
-        /**
          * Gets the right-hand operand of the binary query expression.
          * @return Returns the right-hand operand of the binary query expression.
          */
         query const& operand() const;
-
-        /**
-         * Gets the right-hand operand of the binary query expression.
-         * @return Returns the right-hand operand of the binary query expression.
-         */
-        query& operand();
 
         /**
          * Gets the position of the binary query expression.
@@ -249,22 +219,10 @@ namespace puppet { namespace ast {
         collection_kind kind() const;
 
         /**
-         * Gets the kind of collection expression.
-         * @return Returns the kind of the collection expression.
-         */
-        collection_kind& kind();
-
-        /**
          * Gets the type being collected.
          * @return Returns the type being collected.
          */
         ast::type const& type() const;
-
-        /**
-         * Gets the type being collected.
-         * @return Returns the type being collected.
-         */
-        ast::type& type();
 
         /**
          * Gets the optional first query in the expression.
@@ -273,22 +231,10 @@ namespace puppet { namespace ast {
         boost::optional<query> const& first() const;
 
         /**
-         * Gets the optional first query in the expression.
-         * @return Returns the first query in the expression.
-         */
-        boost::optional<query>& first();
-
-        /**
          * Gets the remainder of the expression (for binary query expressions).
          * @return Returns the remainder of the expression.
          */
         std::vector<binary_query_expression> const& remainder() const;
-
-        /**
-         * Gets the remainder of the expression (for binary query expressions).
-         * @return Returns the remainder of the expression.
-         */
-        std::vector<binary_query_expression>& remainder();
 
         /**
          * Gets the position of the expression.

--- a/lib/include/puppet/ast/defined_type_expression.hpp
+++ b/lib/include/puppet/ast/defined_type_expression.hpp
@@ -37,34 +37,16 @@ namespace puppet { namespace ast {
         ast::name const& name() const;
 
         /**
-         * Gets the name of the type.
-         * @return Returns the name of the type.
-         */
-        ast::name& name();
-
-        /**
          * Gets the type parameters.
          * @return Returns the type parameters.
          */
         boost::optional<std::vector<parameter>> const& parameters() const;
 
         /**
-         * Gets the optional type parameters.
-         * @return Returns the optional type parameters.
-         */
-        boost::optional<std::vector<parameter>>& parameters();
-
-        /**
          * Gets the optional body expressions.
          * @return Returns the optional body expressions.
          */
         boost::optional<std::vector<expression>> const& body() const;
-
-        /**
-         * Gets the optional body expressions.
-         * @return Returns the optional body expressions.
-         */
-        boost::optional<std::vector<expression>>& body();
 
         /**
          * Gets the position of the expression.

--- a/lib/include/puppet/ast/expression.hpp
+++ b/lib/include/puppet/ast/expression.hpp
@@ -182,22 +182,10 @@ namespace puppet { namespace ast {
         unary_operator op() const;
 
         /**
-        * Gets the unary operator for the expression.
-        * @return Returns the unary operator for the expression.
-        */
-        unary_operator& op();
-
-        /**
          * Gets the operand for the expression.
          * @return Returns the operand for the expression.
          */
         primary_expression const& operand() const;
-
-        /**
-         * Gets the operand for the expression.
-         * @return Returns the operand for the expression.
-         */
-        primary_expression& operand();
 
         /**
          * Gets the position of the unary expression.
@@ -354,22 +342,10 @@ namespace puppet { namespace ast {
         binary_operator op() const;
 
         /**
-         * Gets the binary operator in the expression.
-         * @return Returns the binary operator in the expression.
-         */
-        binary_operator& op();
-
-        /**
          * Gets the right-hand operand of the binary expression.
          * @return Returns the right-hand operand of the binary expression.
          */
         primary_expression const& operand() const;
-
-        /**
-         * Gets the right-hand operand the binary expression.
-         * @return Returns the right-hand operand of the binary expression.
-         */
-        primary_expression& operand();
 
         /**
          * Gets the position of the binary expression.
@@ -414,24 +390,11 @@ namespace puppet { namespace ast {
         primary_expression const& first() const;
 
         /**
-         * Gets the first primary expression in the expression.
-         * @return Returns the first primary expression in the expression.
-         */
-        primary_expression& first();
-
-        /**
          * Gets the remainder of the expression (for binary expressions).
          * Empty for unary expressions.
          * @return Returns the remainder of the expression.
          */
         std::vector<binary_expression> const& remainder() const;
-
-        /**
-         * Gets the remainder of the expression (for binary expressions).
-         * Empty for unary expressions.
-         * @return Returns the remainder of the expression.
-         */
-        std::vector<binary_expression>& remainder();
 
         /**
          * Gets the position of the expression.

--- a/lib/include/puppet/ast/function_call_expression.hpp
+++ b/lib/include/puppet/ast/function_call_expression.hpp
@@ -38,34 +38,16 @@ namespace puppet { namespace ast {
         name const& function() const;
 
         /**
-         * Gets the function name.
-         * @return Returns the function name.
-         */
-        name& function();
-
-        /**
          * Gets the optional argument expressions.
          * @return Returns the optional argument expressions.
          */
         boost::optional<std::vector<expression>> const& arguments() const;
 
         /**
-         * Gets the optional argument expressions.
-         * @return Returns the optional argument expressions.
-         */
-        boost::optional<std::vector<expression>>& arguments();
-
-        /**
          * Gets the optional lambda.
          * @return Returns the optional lambda.
          */
         boost::optional<ast::lambda> const& lambda() const;
-
-        /**
-         * Gets the optional lambda.
-         * @return Returns the optional lambda.
-         */
-        boost::optional<ast::lambda>& lambda();
 
         /**
          * Gets the position of the function call expression.

--- a/lib/include/puppet/ast/hash.hpp
+++ b/lib/include/puppet/ast/hash.hpp
@@ -49,12 +49,6 @@ namespace puppet { namespace ast {
         boost::optional<std::vector<hash_pair>> const& elements() const;
 
         /**
-         * Gets the elements (name-value pairs) of the hash.
-         * @return Returns the optional name-value pair elements of the hash.
-         */
-        boost::optional<std::vector<hash_pair>>& elements();
-
-        /**
          * Gets the position of the hash.
          * @return Returns the position of the hash.
          */

--- a/lib/include/puppet/ast/if_expression.hpp
+++ b/lib/include/puppet/ast/if_expression.hpp
@@ -35,12 +35,6 @@ namespace puppet { namespace ast {
         boost::optional<std::vector<expression>> const& body() const;
 
         /**
-         * Gets the optional expression that make up the body.
-         * @return Returns the optional expression that make up the body.
-         */
-        boost::optional<std::vector<expression>>& body();
-
-        /**
          * Gets the position of the "else" expression.
          * @return Returns the position of the "else" expression.
          */
@@ -84,22 +78,10 @@ namespace puppet { namespace ast {
         expression const& conditional() const;
 
         /**
-         * Gets the conditional of the "else if" expression.
-         * @return Returns the conditional of the "else if" expression.
-         */
-        expression& conditional();
-
-        /**
          * Gets the optional expressions that make up the body.
          * @return Returns the optional expressions that make up the body.
          */
         boost::optional<std::vector<expression>> const& body() const;
-
-        /**
-         * Gets the optional expressions that make up the body.
-         * @return Returns the optional expressions that make up the body.
-         */
-        boost::optional<std::vector<expression>>& body();
 
         /**
          * Gets the position of the "else if" expression.
@@ -153,22 +135,10 @@ namespace puppet { namespace ast {
         expression const& conditional() const;
 
         /**
-         * Gets the conditional of the "if" expression.
-         * @return Returns the conditional of the "if" expression.
-         */
-        expression& conditional();
-
-        /**
          * Gets the optional expressions that make up the body.
          * @return Returns the optional expressions that make up the body.
          */
         boost::optional<std::vector<expression>> const& body() const;
-
-        /**
-         * Gets the optional expressions that make up the body.
-         * @return Returns the optional expressions that make up the body.
-         */
-        boost::optional<std::vector<expression>>& body();
 
         /**
          * Gets the optional list of "else if" expressions.
@@ -177,22 +147,10 @@ namespace puppet { namespace ast {
         boost::optional<std::vector<elsif_expression>> const& elsifs() const;
 
         /**
-         * Gets the optional list of "else if" expressions.
-         * @return Returns the optional list of "else if" expressions.
-         */
-        boost::optional<std::vector<elsif_expression>>& elsifs();
-
-        /**
          * Gets the optional "else" expression.
          * @return Returns the optional "else" expression.
          */
         boost::optional<else_expression> const& else_() const;
-
-        /**
-         * Gets the optional "else" expression.
-         * @return Returns the optional "else" expression.
-         */
-        boost::optional<else_expression>& else_();
 
         /**
          * Gets the position of the "if" expression.

--- a/lib/include/puppet/ast/lambda.hpp
+++ b/lib/include/puppet/ast/lambda.hpp
@@ -37,22 +37,10 @@ namespace puppet { namespace ast {
         boost::optional<std::vector<parameter>> const& parameters() const;
 
         /**
-         * Gets the parameters of the lambda.
-         * @return Returns the parameters of the lambda.
-         */
-        boost::optional<std::vector<parameter>>& parameters();
-
-        /**
          * Gets the expressions of the lambda's body.
          * @return Returns the expressions of the lambda's body.
          */
         boost::optional<std::vector<expression>> const& body() const;
-
-        /**
-         * Gets the expressions of the lambda's body.
-         * @return Returns the expressions of the lambda's body.
-         */
-        boost::optional<std::vector<expression>>& body();
 
         /**
          * Gets the position of the lambda.

--- a/lib/include/puppet/ast/manifest.hpp
+++ b/lib/include/puppet/ast/manifest.hpp
@@ -35,12 +35,6 @@ namespace puppet { namespace ast {
         boost::optional<std::vector<expression>> const& body() const;
 
         /**
-         * Gets the expressions that make up the body of the manifest.
-         * @return Returns the expressions that make up the body of the manifest.
-         */
-        boost::optional<std::vector<expression>>& body();
-
-        /**
          * Gets the end token position for interpolation.
          * @return Returns the end token position for interpolation or nullptr if not interpolated.
          */

--- a/lib/include/puppet/ast/method_call_expression.hpp
+++ b/lib/include/puppet/ast/method_call_expression.hpp
@@ -38,34 +38,16 @@ namespace puppet { namespace ast {
         name const& method() const;
 
         /**
-         * Gets the method name.
-         * @return Returns the method name.
-         */
-        name& method();
-
-        /**
          * Gets the optional argument expressions.
          * @return Returns the argument expressions.
          */
         boost::optional<std::vector<expression>> const& arguments() const;
 
         /**
-         * Gets the optional argument expressions.
-         * @return Returns the argument expressions.
-         */
-        boost::optional<std::vector<expression>>& arguments();
-
-        /**
          * Gets the optional lambda.
          * @return Returns the optional lambda.
          */
-        boost::optional<ast:: lambda> const& lambda() const;
-
-        /**
-         * Gets the optional lambda.
-         * @return Returns the optional lambda.
-         */
-        boost::optional<struct lambda>& lambda();
+        boost::optional<ast::lambda> const& lambda() const;
 
         /**
          * Gets the position of the method call expression.
@@ -111,22 +93,10 @@ namespace puppet { namespace ast {
         primary_expression const& target() const;
 
         /**
-         * Gets the target expression.
-         * @return Returns the target expression.
-         */
-        primary_expression& target();
-
-        /**
          * Gets the method calls that make up the expression.
          * @return Returns the method calls in the expression.
          */
         std::vector<method_call> const& calls() const;
-
-        /**
-         * Gets the method calls that make up the expression.
-         * @return Returns the method calls in the expression.
-         */
-        std::vector<method_call>& calls();
 
         /**
          * Gets the position of the method call expression.

--- a/lib/include/puppet/ast/name.hpp
+++ b/lib/include/puppet/ast/name.hpp
@@ -40,12 +40,6 @@ namespace puppet { namespace ast {
         std::string const& value() const;
 
         /**
-         * Gets the value of the name.
-         * @return Returns the value of the name.
-         */
-        std::string& value();
-
-        /**
          * Gets the position of the name.
          * @return Returns the position of the name.
          */

--- a/lib/include/puppet/ast/node_definition_expression.hpp
+++ b/lib/include/puppet/ast/node_definition_expression.hpp
@@ -53,22 +53,10 @@ namespace puppet { namespace ast {
         std::string const& value() const;
 
         /**
-         * Gets the value of the hostname.
-         * @return Returns the value of the hostname.
-         */
-        std::string& value();
-
-        /**
          * Determines if the hostname is a regex.
          * @return Returns true if the hostname is a regex or false if it is a regular string.
          */
         bool regex() const;
-
-        /**
-         * Determines if the hostname is a regex.
-         * @return Returns true if the hostname is a regex or false if it is a regular string.
-         */
-        bool& regex();
 
         /**
          * Determines if the hostname is the default hostname.
@@ -121,22 +109,10 @@ namespace puppet { namespace ast {
         std::vector<hostname> const& names() const;
 
         /**
-         * Gets the list of hostnames for the node definition.
-         * @return Returne the hostnames for the node definition.
-         */
-        std::vector<hostname>& names();
-
-        /**
          * Gets the optionl expressions that make up the definition'd body.
          * @return Returns the optional expressions that make up the definition's body.
          */
         boost::optional<std::vector<expression>> const& body() const;
-
-        /**
-         * Gets the optionl expressions that make up the definition's body.
-         * @return Returns the optional expression that make up the definition's body.
-         */
-        boost::optional<std::vector<expression>>& body();
 
         /**
          * Gets the position of the node definition expression.

--- a/lib/include/puppet/ast/number.hpp
+++ b/lib/include/puppet/ast/number.hpp
@@ -38,12 +38,6 @@ namespace puppet { namespace ast {
         value_type const& value() const;
 
         /**
-         * Gets the value of the number.
-         * @return Returns the value of the number.
-         */
-        value_type& value();
-
-        /**
          * Gets the position of the number.
          * @return Returns the position of the number.
          */

--- a/lib/include/puppet/ast/parameter.hpp
+++ b/lib/include/puppet/ast/parameter.hpp
@@ -100,22 +100,10 @@ namespace puppet { namespace ast {
         boost::optional<parameter_type> const& type() const;
 
         /**
-         * Gets the optional type of the parameter.
-         * @return Returns the optional type of the parameter.
-         */
-        boost::optional<parameter_type>& type();
-
-        /**
          * Determines if the parameter captures the remaining arguments.
          * @return Returns true if the parameter captures the remaining arguments or false if not.
          */
         bool captures() const;
-
-        /**
-         * Determines if the parameter captures the remaining arguments.
-         * @return Returns true if the parameter captures the remaining arguments or false if not.
-         */
-        bool& captures();
 
         /**
          * Gets the variable of the parameter.
@@ -124,22 +112,10 @@ namespace puppet { namespace ast {
         ast::variable const& variable() const;
 
         /**
-         * Gets the variable of the parameter.
-         * @return Returns the variable of the parameter.
-         */
-        ast::variable& variable();
-
-        /**
          * Gets the optional default value expression of the parameter.
          * @return Returns the optional default value expression of the parameter.
          */
         boost::optional<expression> const& default_value() const;
-
-        /**
-         * Gets the optional default value expression of the parameter.
-         * @return Returns the optional default value expression of the parameter.
-         */
-        boost::optional<expression>& default_value();
 
         /**
          * Gets the position of the parameter.

--- a/lib/include/puppet/ast/regex.hpp
+++ b/lib/include/puppet/ast/regex.hpp
@@ -53,12 +53,6 @@ namespace puppet { namespace ast {
         std::string const& value() const;
 
         /**
-         * Gets the value of the regex.
-         * @return Returns the value of the regex.
-         */
-        std::string& value();
-
-        /**
          * Gets the position of the regex.
          * @return Returns the position of the regex.
          */

--- a/lib/include/puppet/ast/resource_defaults_expression.hpp
+++ b/lib/include/puppet/ast/resource_defaults_expression.hpp
@@ -34,22 +34,10 @@ namespace puppet { namespace ast {
         ast::type const& type() const;
 
         /**
-         * Gets the type of the resource being defaulted.
-         * @return Returns the type of the resource being defaulted.
-         */
-        ast::type& type();
-
-        /**
          * Gets the optional attributes being defaulted.
          * @return Returns the attributes being defaulted.
          */
         boost::optional<std::vector<attribute_expression>> const& attributes() const;
-
-        /**
-         * Gets the optional attributes being defaulted.
-        * @return Returns the attributes being defaulted.
-         */
-        boost::optional<std::vector<attribute_expression>>& attributes();
 
         /**
          * Gets the position of the expression.

--- a/lib/include/puppet/ast/resource_expression.hpp
+++ b/lib/include/puppet/ast/resource_expression.hpp
@@ -62,34 +62,16 @@ namespace puppet { namespace ast {
         ast::name const& name() const;
 
         /**
-         * Gets the name of the attribute.
-         * @return Returns the name of the attribute.
-         */
-        ast::name& name();
-
-        /**
          * Gets the attribute operator.
          * @return Returns the attribute operator.
          */
         attribute_operator op() const;
 
         /**
-         * Gets the attribute operator.
-         * @return Returns the attribute operator.
-         */
-        attribute_operator& op();
-
-        /**
          * Gets the attribute's value expression.
          * @return Returns the attribute's value expression.
          */
         expression const& value() const;
-
-        /**
-         * Gets the attribute's value expression.
-         * @return Returns the attribute's value expression.
-         */
-        expression& value();
 
         /**
          * Gets the position of the attribute expression.
@@ -135,22 +117,10 @@ namespace puppet { namespace ast {
         expression const& title() const;
 
         /**
-         * Gets the resource body's title expression.
-         * @return Returns the resource body's title expression.
-         */
-        expression& title();
-
-        /**
          * Gets the optional attributes of the resource.
          * @return Returns optional the attributes of the resource.
          */
         boost::optional<std::vector<attribute_expression>> const& attributes() const;
-
-        /**
-         * Gets the optional attributes of the resource.
-         * @return Returns optional the attributes of the resource.
-         */
-        boost::optional<std::vector<attribute_expression>>& attributes();
 
         /**
          * Gets the position of the resource body.
@@ -219,34 +189,16 @@ namespace puppet { namespace ast {
         expression const& type() const;
 
         /**
-         * Gets the type expression of the resource being defined.
-         * @return Returns the type expression of the resource being defined.
-         */
-        expression& type();
-
-        /**
          * Gets the resource bodies that are being defined.
          * @return Returns the resource bodies that are being defined.
          */
         std::vector<resource_body> bodies() const;
 
         /**
-         * Gets the resource bodies that are being defined.
-         * @return Returns the resource bodies that are being defined.
-         */
-        std::vector<resource_body>& bodies();
-
-        /**
          * Gets the status of the resource.
          * @return Returns the status of the resource.
          */
         resource_status status() const;
-
-        /**
-         * Gets the status of the resource.
-         * @return Returns the status of the resource.
-         */
-        resource_status& status();
 
         /**
          * Gets the position of the resource expression.

--- a/lib/include/puppet/ast/resource_override_expression.hpp
+++ b/lib/include/puppet/ast/resource_override_expression.hpp
@@ -35,22 +35,10 @@ namespace puppet { namespace ast {
         expression const& reference() const;
 
         /**
-         * Gets the reference expression for the resources being overriden.
-         * @return Returns the reference expression for the resources being overriden.
-         */
-        expression& reference();
-
-        /**
          * Gets the optional attributes being overridden.
          * @return Returns the attributes being overridden.
          */
         boost::optional<std::vector<attribute_expression>> const& attributes() const;
-
-        /**
-         * Gets the optional attributes being overridden.
-         * @return Returns the attributes being overridden.
-         */
-        boost::optional<std::vector<attribute_expression>>& attributes();
 
         /**
          * Gets the position of the resource override expression.

--- a/lib/include/puppet/ast/selector_expression.hpp
+++ b/lib/include/puppet/ast/selector_expression.hpp
@@ -39,22 +39,10 @@ namespace puppet { namespace ast {
         expression const& selector() const;
 
         /**
-         * Gets the selector expression.
-         * @return Returns the selector expression.
-         */
-        expression& selector();
-
-        /**
          * Gets the result expression.
          * @return Returns the result expression.
          */
         expression const& result() const;
-
-        /**
-         * Gets the result expression.
-         * @return Returns the result expression.
-         */
-        expression& result();
 
         /**
          * Determines if the expression is for the default case.
@@ -106,22 +94,10 @@ namespace puppet { namespace ast {
         primary_expression const& value() const;
 
         /**
-         * Gets the value of the selector expression.
-         * @return Returns the value of the selector expression.
-         */
-        primary_expression& value();
-
-        /**
          * Gets the selector case expressions.
          * @return Returns the selector case expressions.
          */
         std::vector<selector_case_expression> const& cases() const;
-
-        /**
-         * Gets the selector case expressions.
-         * @return Returns the selector case expressions.
-         */
-        std::vector<selector_case_expression>& cases();
 
         /**
          * Gets the position of the selector expression.

--- a/lib/include/puppet/ast/type.hpp
+++ b/lib/include/puppet/ast/type.hpp
@@ -40,12 +40,6 @@ namespace puppet { namespace ast {
         std::string const& name() const;
 
         /**
-         * Gets the name of the type.
-         * @return Returns the name of the type.
-         */
-        std::string& name();
-
-        /**
          * Gets the position of the type.
          * @return Returns the position of the type.
          */

--- a/lib/include/puppet/ast/unless_expression.hpp
+++ b/lib/include/puppet/ast/unless_expression.hpp
@@ -38,34 +38,15 @@ namespace puppet { namespace ast {
         expression const& conditional() const;
 
         /**
-         * Gets the conditional of the "unless" expression.
-         * @return Returns the conditional of the "unless" expression.
-         */
-        expression& conditional();
-
-        /**
          * Gets the optional expressions that make up the body.
          * @return Returns the optional expressions that make up the body.
          */
         boost::optional<std::vector<expression>> const& body() const;
-
-        /**
-         * Gets the optional expressions that make up the body.
-         * @return Returns the optional expressions that make up the body.
-         */
-        boost::optional<std::vector<expression>>& body();
-
         /**
          * Gets the optional "else" expression.
          * @return Returns the optional "else" expression.
          */
         boost::optional<else_expression> const& else_() const;
-
-        /**
-         * Gets the optional "else" expression.
-         * @return Returns the optional "else" expression.
-         */
-        boost::optional<else_expression>& else_();
 
         /**
          * Gets the position of the "unless" expression.

--- a/lib/include/puppet/ast/variable.hpp
+++ b/lib/include/puppet/ast/variable.hpp
@@ -50,12 +50,6 @@ namespace puppet { namespace ast {
         std::string const& name() const;
 
         /**
-         * Gets the name of the variable.
-         * @return Returns the name of the variable.
-         */
-        std::string& name();
-
-        /**
          * Gets the position of the variable.
          * @return Returns the position of the variable.
          */

--- a/lib/include/puppet/lexer/lexer.hpp
+++ b/lib/include/puppet/lexer/lexer.hpp
@@ -326,7 +326,7 @@ namespace puppet { namespace lexer {
                 ("info",    static_cast<id_type>(token_id::statement_call))
                 ("notice",  static_cast<id_type>(token_id::statement_call))
                 ("warning", static_cast<id_type>(token_id::statement_call))
-                ("error",   static_cast<id_type>(token_id::statement_call))
+                ("err",     static_cast<id_type>(token_id::statement_call))
                 ("fail",    static_cast<id_type>(token_id::statement_call))
                 ("import",  static_cast<id_type>(token_id::statement_call));
 

--- a/lib/include/puppet/logging/logger.hpp
+++ b/lib/include/puppet/logging/logger.hpp
@@ -24,6 +24,10 @@ namespace puppet { namespace logging {
          */
         info,
         /**
+         * The notice log level.
+         */
+        notice,
+        /**
          * The warning log level.
          */
         warning,
@@ -32,9 +36,17 @@ namespace puppet { namespace logging {
          */
         error,
         /**
-         * The fatal error log level.
+         * The alert log level.
          */
-        fatal
+        alert,
+        /**
+         * The emergency log level.
+         */
+        emergency,
+        /**
+         * The critical error log level.
+         */
+        critical
     };
 
     /**

--- a/lib/include/puppet/runtime/expression_evaluator.hpp
+++ b/lib/include/puppet/runtime/expression_evaluator.hpp
@@ -50,7 +50,7 @@ namespace puppet { namespace runtime {
          * @param expr The AST expression to evaluate.
          * @return Returns the runtime value that is the result of evaluating the expression.
          */
-        value evaluate(ast::expression& expr);
+        value evaluate(ast::expression const& expr);
 
         /**
          * Gets the evaluation context.
@@ -69,8 +69,8 @@ namespace puppet { namespace runtime {
             value& left,
             lexer::token_position& left_position,
             std::uint8_t min_precedence,
-            std::vector<ast::binary_expression>::iterator& begin,
-            std::vector<ast::binary_expression>::iterator const& end
+            std::vector<ast::binary_expression>::const_iterator& begin,
+            std::vector<ast::binary_expression>::const_iterator const& end
         );
 
         void evaluate(

--- a/lib/include/puppet/runtime/functions/fail.hpp
+++ b/lib/include/puppet/runtime/functions/fail.hpp
@@ -1,0 +1,29 @@
+/**
+ * @file
+ * Declares the fail function.
+ */
+#pragma once
+
+#include "../context.hpp"
+#include "../value.hpp"
+#include "../yielder.hpp"
+
+namespace puppet { namespace runtime { namespace functions {
+
+    /**
+     * Implements the "fail" function.
+     */
+    struct fail
+    {
+        /**
+         * Called to invoke the function.
+         * @param ctx The current evaluation context.
+         * @param position The position where the function call is.
+         * @param arguments The arguments to the function.
+         * @param yielder The yielder to use for invoking a lambda.
+         * @return Returns the resulting value.
+         */
+        value operator()(context& ctx, lexer::token_position const& position, array& arguments, runtime::yielder& yielder) const;
+    };
+
+}}}  // puppet::runtime::functions

--- a/lib/include/puppet/runtime/functions/logging.hpp
+++ b/lib/include/puppet/runtime/functions/logging.hpp
@@ -1,0 +1,38 @@
+/**
+ * @file
+ * Declares the logging functions.
+ */
+#pragma once
+
+#include "../context.hpp"
+#include "../value.hpp"
+#include "../yielder.hpp"
+
+namespace puppet { namespace runtime { namespace functions {
+
+    /**
+     * Implements the logging functions (debug, info, notice, warning, err, etc.)
+     */
+    struct logging_function
+    {
+        /**
+         * Constructs a logging function with the given log level.
+         * @param lvl The log level to use when invoked.
+         */
+        explicit logging_function(logging::level lvl);
+
+        /**
+         * Called to invoke the function.
+         * @param ctx The current evaluation context.
+         * @param position The position where the function call is.
+         * @param arguments The arguments to the function.
+         * @param yielder The yielder to use for invoking a lambda.
+         * @return Returns the resulting value.
+         */
+        value operator()(context& ctx, lexer::token_position const& position, array& arguments, runtime::yielder& yielder) const;
+
+     private:
+        logging::level _level;
+    };
+
+}}}  // puppet::runtime::functions

--- a/lib/include/puppet/runtime/functions/with.hpp
+++ b/lib/include/puppet/runtime/functions/with.hpp
@@ -1,0 +1,29 @@
+/**
+ * @file
+ * Declares the with function.
+ */
+#pragma once
+
+#include "../context.hpp"
+#include "../value.hpp"
+#include "../yielder.hpp"
+
+namespace puppet { namespace runtime { namespace functions {
+
+    /**
+     * Implements the "with" function.
+     */
+    struct with
+    {
+        /**
+         * Called to invoke the function.
+         * @param ctx The current evaluation context.
+         * @param position The position where the function call is.
+         * @param arguments The arguments to the function.
+         * @param yielder The yielder to use for invoking a lambda.
+         * @return Returns the resulting value.
+         */
+        value operator()(context& ctx, lexer::token_position const& position, array& arguments, runtime::yielder& yielder) const;
+    };
+
+}}}  // puppet::runtime::functions

--- a/lib/include/puppet/runtime/scope.hpp
+++ b/lib/include/puppet/runtime/scope.hpp
@@ -38,10 +38,9 @@ namespace puppet { namespace runtime {
          * Sets a variable in the scope.
          * @param name The name of the variable.
          * @param val The value of the variable.
-         * @param line The line where the variable was assigned.
          * @return Returns a pointer to the value that was set or nullptr if the value already exists in this scope.
          */
-        value const* set(std::string name, value val, std::uint32_t line);
+        value const* set(std::string name, value val);
 
         /**
          * Gets a variable in the scope.
@@ -49,13 +48,6 @@ namespace puppet { namespace runtime {
          * @return Returns the value of the variable or nullptr if the value does not exist.
          */
         value const* get(std::string const& name) const;
-
-        /**
-         * Determines the line where a variable was set.
-         * @param name The name of the variable.
-         * @return Returns the line where the variable was set (0 if from facts) or nullptr if no such variable.
-         */
-        boost::optional<uint32_t> where(std::string const& name) const;
 
         /**
          * Gets the parent scope.
@@ -90,7 +82,7 @@ namespace puppet { namespace runtime {
      private:
         std::string _name;
         std::shared_ptr<scope> _parent;
-        std::unordered_map<std::string, std::tuple<value, std::uint32_t>> _variables;
+        std::unordered_map<std::string, value> _variables;
         std::deque<std::vector<value>> _matches;
     };
 
@@ -101,5 +93,25 @@ namespace puppet { namespace runtime {
      * @return Returns the given output stream.
      */
     std::ostream& operator<<(std::ostream& os, scope const& s);
+
+    /**
+     * Represents a match variable scope.
+     */
+    struct match_variable_scope
+    {
+        /**
+         * Constructs a match variable scope.
+         * @param current The current scope.
+         */
+        explicit match_variable_scope(scope& current);
+
+        /**
+         * Destructs a match variable scope.
+         */
+        ~match_variable_scope();
+
+     private:
+        scope& _current;
+    };
 
 }}  // puppet::runtime

--- a/lib/include/puppet/runtime/value.hpp
+++ b/lib/include/puppet/runtime/value.hpp
@@ -463,6 +463,14 @@ namespace puppet { namespace runtime {
     array to_array(value const& val);
 
     /**
+     * Joins the array by converting each element to a string.
+     * @param os The output stream to write to.
+     * @param arr The array to join.
+     * @param separator The separator to write between array elements.
+     */
+    void join(std::ostream& os, array const& arr, std::string const& separator = " ");
+
+    /**
      * Equality operator for undef.
      * @return Always returns true.
      */

--- a/lib/include/puppet/runtime/yielder.hpp
+++ b/lib/include/puppet/runtime/yielder.hpp
@@ -1,0 +1,58 @@
+/**
+ * @file
+ * Declares the lambda yielder.
+ */
+#pragma once
+
+#include "../ast/lambda.hpp"
+#include "value.hpp"
+#include "expression_evaluator.hpp"
+#include <boost/optional.hpp>
+#include <vector>
+#include <functional>
+#include <unordered_map>
+#include <string>
+
+namespace puppet { namespace runtime {
+
+    /**
+     * Represents the lambda yielder.
+     */
+    struct yielder
+    {
+        /**
+         * Constructs a lambda yielder.
+         * @param evaluator The current expression evaluator.
+         * @param position The position of the function call that was passed the lambda.
+         * @param lambda The AST lambda being yielded to.
+         */
+        yielder(expression_evaluator& evaluator, lexer::token_position const& position, boost::optional<ast::lambda> const& lambda);
+
+        /**
+         * Determines if the lambda was given to the function.
+         * @return Returns true if the lambda was given or false if not.
+         */
+        bool lambda_given() const;
+
+        /**
+         * Yields to the lambda without passing any arguments.
+         * @return Returns the value from the lambda's block.
+         */
+        value yield();
+
+        /**
+         * Yields to the lambda with the given arguments.
+         * Note: elements of the array may be mutated.
+         * @param arguments The arguments to pass to the lambda.
+         * @return Returns the value from the lambda's block.
+         */
+        value yield(array& arguments);
+
+     private:
+        expression_evaluator& _evaluator;
+        lexer::token_position const& _position;
+        boost::optional<ast::lambda> const& _lambda;
+        std::unordered_map<std::string, value> _default_cache;
+    };
+
+}}  // puppet::runtime

--- a/lib/src/ast/access_expression.cc
+++ b/lib/src/ast/access_expression.cc
@@ -23,11 +23,6 @@ namespace puppet { namespace ast {
         return _arguments;
     }
 
-    vector<expression>& access::arguments()
-    {
-        return _arguments;
-    }
-
     token_position const& access::position() const
     {
         return _position;
@@ -56,17 +51,7 @@ namespace puppet { namespace ast {
         return _target;
     }
 
-    primary_expression& access_expression::target()
-    {
-        return _target;
-    }
-
     vector<access> const& access_expression::accesses() const
-    {
-        return _accesses;
-    }
-
-    vector<access>& access_expression::accesses()
     {
         return _accesses;
     }

--- a/lib/src/ast/array.cc
+++ b/lib/src/ast/array.cc
@@ -24,11 +24,6 @@ namespace puppet { namespace ast {
         return _elements;
     }
 
-    optional<vector<expression>>& array::elements()
-    {
-        return _elements;
-    }
-
     token_position const& array::position() const
     {
         return _position;

--- a/lib/src/ast/boolean.cc
+++ b/lib/src/ast/boolean.cc
@@ -21,11 +21,6 @@ namespace puppet { namespace ast {
         return _value;
     }
 
-    bool& boolean::value()
-    {
-        return _value;
-    }
-
     token_position const& boolean::position() const
     {
         return _position;

--- a/lib/src/ast/case_expression.cc
+++ b/lib/src/ast/case_expression.cc
@@ -32,17 +32,7 @@ namespace puppet { namespace ast {
         return _options;
     }
 
-    vector<expression>& case_proposition::options()
-    {
-        return _options;
-    }
-
     optional<vector<expression>> const& case_proposition::body() const
-    {
-        return _body;
-    }
-
-    optional<vector<expression>>& case_proposition::body()
     {
         return _body;
     }
@@ -86,17 +76,7 @@ namespace puppet { namespace ast {
         return _expression;
     }
 
-    expression& case_expression::expression()
-    {
-        return _expression;
-    }
-
     vector<case_proposition> const& case_expression::propositions() const
-    {
-        return _propositions;
-    }
-
-    vector<case_proposition>& case_expression::propositions()
     {
         return _propositions;
     }

--- a/lib/src/ast/class_definition_expression.cc
+++ b/lib/src/ast/class_definition_expression.cc
@@ -26,17 +26,7 @@ namespace puppet { namespace ast {
         return _name;
     }
 
-    ast::name& class_definition_expression::name()
-    {
-        return _name;
-    }
-
     optional<vector<parameter>> const& class_definition_expression::parameters() const
-    {
-        return _parameters;
-    }
-
-    optional<vector<parameter>>& class_definition_expression::parameters()
     {
         return _parameters;
     }
@@ -46,17 +36,7 @@ namespace puppet { namespace ast {
         return _parent;
     }
 
-    optional<ast::name>& class_definition_expression::parent()
-    {
-        return _parent;
-    }
-
     optional<vector<expression>> const& class_definition_expression::body() const
-    {
-        return _body;
-    }
-
-    optional<vector<expression>>& class_definition_expression::body()
     {
         return _body;
     }

--- a/lib/src/ast/collection_expression.cc
+++ b/lib/src/ast/collection_expression.cc
@@ -41,27 +41,12 @@ namespace puppet { namespace ast {
         return _attribute;
     }
 
-    name& query::attribute()
-    {
-        return _attribute;
-    }
-
     attribute_query_operator query::op() const
     {
         return _op;
     }
 
-    attribute_query_operator& query::op()
-    {
-        return _op;
-    }
-
     basic_expression const& query::value() const
-    {
-        return _value;
-    }
-
-    basic_expression& query::value()
     {
         return _value;
     }
@@ -113,17 +98,7 @@ namespace puppet { namespace ast {
         return _op;
     }
 
-    binary_query_operator& binary_query_expression::op()
-    {
-        return _op;
-    }
-
     query const& binary_query_expression::operand() const
-    {
-        return _operand;
-    }
-
-    query& binary_query_expression::operand()
     {
         return _operand;
     }
@@ -161,17 +136,7 @@ namespace puppet { namespace ast {
         return _kind;
     }
 
-    collection_kind& collection_expression::kind()
-    {
-        return _kind;
-    }
-
     ast::type const& collection_expression::type() const
-    {
-        return _type;
-    }
-
-    ast::type& collection_expression::type()
     {
         return _type;
     }
@@ -181,17 +146,7 @@ namespace puppet { namespace ast {
         return _first;
     }
 
-    optional<query>& collection_expression::first()
-    {
-        return _first;
-    }
-
     vector<binary_query_expression> const& collection_expression::remainder() const
-    {
-        return _remainder;
-    }
-
-    vector<binary_query_expression>& collection_expression::remainder()
     {
         return _remainder;
     }

--- a/lib/src/ast/defined_type_expression.cc
+++ b/lib/src/ast/defined_type_expression.cc
@@ -24,27 +24,12 @@ namespace puppet { namespace ast {
         return _name;
     }
 
-    ast::name& defined_type_expression::name()
-    {
-        return _name;
-    }
-
     optional<vector<parameter>> const& defined_type_expression::parameters() const
     {
         return _parameters;
     }
 
-    optional<vector<parameter>>& defined_type_expression::parameters()
-    {
-        return _parameters;
-    }
-
     optional<vector<expression>> const& defined_type_expression::body() const
-    {
-        return _body;
-    }
-
-    optional<vector<expression>>& defined_type_expression::body()
     {
         return _body;
     }

--- a/lib/src/ast/expression.cc
+++ b/lib/src/ast/expression.cc
@@ -110,17 +110,7 @@ namespace puppet { namespace ast {
         return _op;
     }
 
-    unary_operator& unary_expression::op()
-    {
-        return _op;
-    }
-
     primary_expression const& unary_expression::operand() const
-    {
-        return _operand;
-    }
-
-    primary_expression& unary_expression::operand()
     {
         return _operand;
     }
@@ -237,17 +227,7 @@ namespace puppet { namespace ast {
         return _op;
     }
 
-    binary_operator& binary_expression::op()
-    {
-        return _op;
-    }
-
     primary_expression const& binary_expression::operand() const
-    {
-        return _operand;
-    }
-
-    primary_expression& binary_expression::operand()
     {
         return _operand;
     }
@@ -281,17 +261,7 @@ namespace puppet { namespace ast {
         return _first;
     }
 
-    primary_expression& expression::first()
-    {
-        return _first;
-    }
-
     vector<binary_expression> const& expression::remainder() const
-    {
-        return _remainder;
-    }
-
-    vector<binary_expression>& expression::remainder()
     {
         return _remainder;
     }

--- a/lib/src/ast/function_call_expression.cc
+++ b/lib/src/ast/function_call_expression.cc
@@ -24,27 +24,12 @@ namespace puppet { namespace ast {
         return _function;
     }
 
-    name& function_call_expression::function()
-    {
-        return _function;
-    }
-
     optional<vector<expression>> const& function_call_expression::arguments() const
     {
         return _arguments;
     }
 
-    optional<vector<expression>>& function_call_expression::arguments()
-    {
-        return _arguments;
-    }
-
     optional<lambda> const& function_call_expression::lambda() const
-    {
-        return _lambda;
-    }
-
-    optional<lambda>& function_call_expression::lambda()
     {
         return _lambda;
     }

--- a/lib/src/ast/hash.cc
+++ b/lib/src/ast/hash.cc
@@ -30,11 +30,6 @@ namespace puppet { namespace ast {
         return _elements;
     }
 
-    optional<vector<hash_pair>>& hash::elements()
-    {
-        return _elements;
-    }
-
     lexer::token_position const& hash::position() const
     {
         return _position;

--- a/lib/src/ast/if_expression.cc
+++ b/lib/src/ast/if_expression.cc
@@ -23,11 +23,6 @@ namespace puppet { namespace ast {
         return _body;
     }
 
-    optional<vector<expression>>& else_expression::body()
-    {
-        return _body;
-    }
-
     ostream& operator<<(ostream& os, else_expression const& expr)
     {
         os << "else { ";
@@ -52,17 +47,7 @@ namespace puppet { namespace ast {
         return _conditional;
     }
 
-    expression& elsif_expression::conditional()
-    {
-        return _conditional;
-    }
-
     optional<vector<expression>> const& elsif_expression::body() const
-    {
-        return _body;
-    }
-
-    optional<vector<expression>>& elsif_expression::body()
     {
         return _body;
     }
@@ -101,17 +86,7 @@ namespace puppet { namespace ast {
         return _conditional;
     }
 
-    expression& if_expression::conditional()
-    {
-        return _conditional;
-    }
-
     optional<vector<expression>> const& if_expression::body() const
-    {
-        return _body;
-    }
-
-    optional<vector<expression>>& if_expression::body()
     {
         return _body;
     }
@@ -121,17 +96,7 @@ namespace puppet { namespace ast {
         return _elsifs;
     }
 
-    optional<vector<elsif_expression>>& if_expression::elsifs()
-    {
-        return _elsifs;
-    }
-
     optional<else_expression> const& if_expression::else_() const
-    {
-        return _else;
-    }
-
-    optional<else_expression>& if_expression::else_()
     {
         return _else;
     }

--- a/lib/src/ast/lambda.cc
+++ b/lib/src/ast/lambda.cc
@@ -24,17 +24,7 @@ namespace puppet { namespace ast {
         return _parameters;
     }
 
-    optional<vector<parameter>>& lambda::parameters()
-    {
-        return _parameters;
-    }
-
     optional<vector<expression>> const& lambda::body() const
-    {
-        return _body;
-    }
-
-    optional<vector<expression>>& lambda::body()
     {
         return _body;
     }

--- a/lib/src/ast/manifest.cc
+++ b/lib/src/ast/manifest.cc
@@ -22,11 +22,6 @@ namespace puppet { namespace ast {
         return _body;
     }
 
-    optional<vector<expression>>& manifest::body()
-    {
-        return _body;
-    }
-
     lexer::token_position const& manifest::end() const
     {
         return _end;

--- a/lib/src/ast/method_call_expression.cc
+++ b/lib/src/ast/method_call_expression.cc
@@ -24,27 +24,12 @@ namespace puppet { namespace ast {
         return _method;
     }
 
-    name& method_call::method()
-    {
-        return _method;
-    }
-
     optional<vector<expression>> const& method_call::arguments() const
     {
         return _arguments;
     }
 
-    optional<vector<expression>>& method_call::arguments()
-    {
-        return _arguments;
-    }
-
     optional<lambda> const& method_call::lambda() const
-    {
-        return _lambda;
-    }
-
-    optional<lambda>& method_call::lambda()
     {
         return _lambda;
     }
@@ -83,17 +68,7 @@ namespace puppet { namespace ast {
         return _target;
     }
 
-    primary_expression& method_call_expression::target()
-    {
-        return _target;
-    }
-
     vector<method_call> const& method_call_expression::calls() const
-    {
-        return _calls;
-    }
-
-    vector<method_call>& method_call_expression::calls()
     {
         return _calls;
     }

--- a/lib/src/ast/name.cc
+++ b/lib/src/ast/name.cc
@@ -14,11 +14,6 @@ namespace puppet { namespace ast {
         return _value;
     }
 
-    string& name::value()
-    {
-        return _value;
-    }
-
     token_position const& name::position() const
     {
         return _position;

--- a/lib/src/ast/node_definition_expression.cc
+++ b/lib/src/ast/node_definition_expression.cc
@@ -92,17 +92,7 @@ namespace puppet { namespace ast {
         return _value;
     }
 
-    std::string& hostname::value()
-    {
-        return _value;
-    }
-
     bool hostname::regex() const
-    {
-        return _regex;
-    }
-
-    bool& hostname::regex()
     {
         return _regex;
     }
@@ -143,17 +133,7 @@ namespace puppet { namespace ast {
         return _names;
     }
 
-    vector<hostname>& node_definition_expression::names()
-    {
-        return _names;
-    }
-
     optional<vector<expression>> const& node_definition_expression::body() const
-    {
-        return _body;
-    }
-
-    optional<vector<expression>>& node_definition_expression::body()
     {
         return _body;
     }

--- a/lib/src/ast/number.cc
+++ b/lib/src/ast/number.cc
@@ -20,11 +20,6 @@ namespace puppet { namespace ast {
         return _value;
     }
 
-    number::value_type& number::value()
-    {
-        return _value;
-    }
-
     token_position const& number::position() const
     {
         return _position;

--- a/lib/src/ast/parameter.cc
+++ b/lib/src/ast/parameter.cc
@@ -73,17 +73,7 @@ namespace puppet { namespace ast {
         return _type;
     }
 
-    optional<parameter_type>& parameter::type()
-    {
-        return _type;
-    }
-
     bool parameter::captures() const
-    {
-        return _captures;
-    }
-
-    bool& parameter::captures()
     {
         return _captures;
     }
@@ -93,17 +83,7 @@ namespace puppet { namespace ast {
         return _variable;
     }
 
-    variable& parameter::variable()
-    {
-        return _variable;
-    }
-
     optional<expression> const& parameter::default_value() const
-    {
-        return _default_value;
-    }
-
-    optional<expression>& parameter::default_value()
     {
         return _default_value;
     }

--- a/lib/src/ast/regex.cc
+++ b/lib/src/ast/regex.cc
@@ -14,11 +14,6 @@ namespace puppet { namespace ast {
         return _value;
     }
 
-    string& regex::value()
-    {
-        return _value;
-    }
-
     token_position const& regex::position() const
     {
         return _position;

--- a/lib/src/ast/resource_defaults_expression.cc
+++ b/lib/src/ast/resource_defaults_expression.cc
@@ -22,17 +22,7 @@ namespace puppet { namespace ast {
         return _type;
     }
 
-    ast::type& resource_defaults_expression::type()
-    {
-        return _type;
-    }
-
     optional<vector<attribute_expression>> const& resource_defaults_expression::attributes() const
-    {
-        return _attributes;
-    }
-
-    optional<vector<attribute_expression>>& resource_defaults_expression::attributes()
     {
         return _attributes;
     }

--- a/lib/src/ast/resource_expression.cc
+++ b/lib/src/ast/resource_expression.cc
@@ -45,27 +45,12 @@ namespace puppet { namespace ast {
         return _name;
     }
 
-    name& attribute_expression::name()
-    {
-        return _name;
-    }
-
     attribute_operator attribute_expression::op() const
     {
         return _op;
     }
 
-    attribute_operator& attribute_expression::op()
-    {
-        return _op;
-    }
-
     expression const& attribute_expression::value() const
-    {
-        return _value;
-    }
-
-    expression& attribute_expression::value()
     {
         return _value;
     }
@@ -99,17 +84,7 @@ namespace puppet { namespace ast {
         return _title;
     }
 
-    expression& resource_body::title()
-    {
-        return _title;
-    }
-
     optional<vector<attribute_expression>> const& resource_body::attributes() const
-    {
-        return _attributes;
-    }
-
-    optional<vector<attribute_expression>>& resource_body::attributes()
     {
         return _attributes;
     }
@@ -147,27 +122,12 @@ namespace puppet { namespace ast {
         return _type;
     }
 
-    expression& resource_expression::type()
-    {
-        return _type;
-    }
-
     vector<resource_body> resource_expression::bodies() const
     {
         return _bodies;
     }
 
-    vector<resource_body>& resource_expression::bodies()
-    {
-        return _bodies;
-    }
-
     resource_status resource_expression::status() const
-    {
-        return _status;
-    }
-
-    resource_status& resource_expression::status()
     {
         return _status;
     }

--- a/lib/src/ast/resource_override_expression.cc
+++ b/lib/src/ast/resource_override_expression.cc
@@ -22,17 +22,7 @@ namespace puppet { namespace ast {
         return _reference;
     }
 
-    expression& resource_override_expression::reference()
-    {
-        return _reference;
-    }
-
     optional<vector<attribute_expression>> const& resource_override_expression::attributes() const
-    {
-        return _attributes;
-    }
-
-    optional<vector<attribute_expression>>& resource_override_expression::attributes()
     {
         return _attributes;
     }

--- a/lib/src/ast/selector_expression.cc
+++ b/lib/src/ast/selector_expression.cc
@@ -29,17 +29,7 @@ namespace puppet { namespace ast {
         return _selector;
     }
 
-    expression& selector_case_expression::selector()
-    {
-        return _selector;
-    }
-
     expression const& selector_case_expression::result() const
-    {
-        return _result;
-    }
-
-    expression& selector_case_expression::result()
     {
         return _result;
     }
@@ -80,17 +70,7 @@ namespace puppet { namespace ast {
         return _value;
     }
 
-    primary_expression& selector_expression::value()
-    {
-        return _value;
-    }
-
     vector<selector_case_expression> const& selector_expression::cases() const
-    {
-        return _cases;
-    }
-
-    vector<selector_case_expression>& selector_expression::cases()
     {
         return _cases;
     }

--- a/lib/src/ast/type.cc
+++ b/lib/src/ast/type.cc
@@ -14,11 +14,6 @@ namespace puppet { namespace ast {
         return _name;
     }
 
-    string& type::name()
-    {
-        return _name;
-    }
-
     token_position const& type::position() const
     {
         return _position;

--- a/lib/src/ast/unless_expression.cc
+++ b/lib/src/ast/unless_expression.cc
@@ -25,27 +25,12 @@ namespace puppet { namespace ast {
         return _conditional;
     }
 
-    expression& unless_expression::conditional()
-    {
-        return _conditional;
-    }
-
     optional<vector<expression>> const& unless_expression::body() const
     {
         return _body;
     }
 
-    optional<vector<expression>>& unless_expression::body()
-    {
-        return _body;
-    }
-
     optional<else_expression> const& unless_expression::else_() const
-    {
-        return _else;
-    }
-
-    optional<else_expression>& unless_expression::else_()
     {
         return _else;
     }

--- a/lib/src/ast/variable.cc
+++ b/lib/src/ast/variable.cc
@@ -21,11 +21,6 @@ namespace puppet { namespace ast {
         return _name;
     }
 
-    string& variable::name()
-    {
-        return _name;
-    }
-
     token_position const& variable::position() const
     {
         return _position;

--- a/lib/src/logging/logger.cc
+++ b/lib/src/logging/logger.cc
@@ -22,7 +22,7 @@ namespace puppet { namespace logging {
     {
         if (lvl == level::warning) {
             ++_warnings;
-        } else if (lvl == level::error || lvl == level::fatal) {
+        } else if (lvl >= level::error) {
             ++_errors;
         }
         log_message(lvl, line, column, text, path, message);
@@ -58,8 +58,8 @@ namespace puppet { namespace logging {
     {
         static const string cyan = "\33[0;36m";
         static const string green = "\33[0;32m";
-        static const string yellow = "\33[0;33m";
-        static const string red = "\33[0;31m";
+        static const string hyellow = "\33[1;33m";
+        static const string hred = "\33[1;31m";
         static const string reset = "\33[0m";
 
         // TODO: don't output color codes for platforms that don't support them (also non-TTY)
@@ -68,9 +68,28 @@ namespace puppet { namespace logging {
         } else if (lvl == level::info) {
             _out << green;
         } else if (lvl == level::warning) {
-            _out << yellow;
-        } else if (lvl == level::error || lvl == level::fatal) {
-            _out << red;
+            _out << hyellow;
+        } else if (lvl >= level::error) {
+            _out << hred;
+        }
+
+       // Output the level
+        if (lvl == level::debug) {
+            _out << "Debug: ";
+        } else if (lvl == level::info) {
+            _out << "Info: ";
+        } else if (lvl == level::notice) {
+            _out << "Notice: ";
+        } else if (lvl == level::warning) {
+            _out << "Warning: ";
+        } else if (lvl == level::error) {
+            _out << "Error: ";
+        } else if (lvl == level::alert) {
+            _out << "Alert: ";
+        } else if (lvl == level::emergency) {
+            _out << "Emergency: ";
+        } else if (lvl == level::critical) {
+            _out << "Critical: ";
         }
 
         // If a location was given, write it out
@@ -85,23 +104,11 @@ namespace puppet { namespace logging {
             _out << ": ";
         }
 
-        // Output the level
-        if (lvl == level::debug) {
-            _out << "debug: ";
-        } else if (lvl == level::info) {
-            _out << "info: ";
-        } else if (lvl == level::warning) {
-            _out << "warning: ";
-        } else if (lvl == level::error) {
-            _out << "error: ";
-        } else if (lvl == level::fatal) {
-            _out << "fatal: ";
-        }
-
         // Output the message
         if (!message.empty()) {
             _out << message;
         }
+
         _out << "\n";
 
         // Output the offending line's text
@@ -110,7 +117,10 @@ namespace puppet { namespace logging {
             _out << setfill(' ') << setw(column + 5) << "^\n";
         }
 
-        _out << reset;
+        // Reset unless the level was notice (no color)
+        if (lvl != level::notice) {
+            _out << reset;
+        }
     }
 
 }}  // namespace puppet::logging

--- a/lib/src/runtime/functions/fail.cc
+++ b/lib/src/runtime/functions/fail.cc
@@ -1,0 +1,20 @@
+#include <puppet/runtime/functions/fail.hpp>
+#include <puppet/runtime/expression_evaluator.hpp>
+
+using namespace std;
+using namespace puppet::lexer;
+
+namespace puppet { namespace runtime { namespace functions {
+
+    value fail::operator()(context& ctx, token_position const& position, array& arguments, runtime::yielder& yielder) const
+    {
+        ostringstream ss;
+        ss << "evaluation failed";
+        if (!arguments.empty()) {
+            ss << ": ";
+            join(ss, arguments, " ");
+        }
+        throw evaluation_exception(position, ss.str());
+    }
+
+}}}  // namespace puppet::runtime::functions

--- a/lib/src/runtime/functions/logging.cc
+++ b/lib/src/runtime/functions/logging.cc
@@ -1,0 +1,26 @@
+#include <puppet/runtime/functions/logging.hpp>
+
+using namespace std;
+using namespace puppet::lexer;
+
+namespace puppet { namespace runtime { namespace functions {
+
+    logging_function::logging_function(logging::level lvl) :
+        _level(lvl)
+    {
+    }
+
+    value logging_function::operator()(context& ctx, token_position const& position, array& arguments, runtime::yielder& yielder) const
+    {
+        // Format the message based on the arguments
+        ostringstream ss;
+        ss << ctx.current() << ": ";
+        join(ss, arguments, " ");
+
+        string message = ss.str();
+
+        ctx.logger().log(_level, message);
+        return arguments.empty() ? value() : message;
+    }
+
+}}}  // namespace puppet::runtime::functions

--- a/lib/src/runtime/functions/with.cc
+++ b/lib/src/runtime/functions/with.cc
@@ -1,0 +1,14 @@
+#include <puppet/runtime/functions/with.hpp>
+#include <puppet/runtime/expression_evaluator.hpp>
+
+using namespace std;
+using namespace puppet::lexer;
+
+namespace puppet { namespace runtime { namespace functions {
+
+    value with::operator()(context& ctx, token_position const& position, array& arguments, runtime::yielder& yielder) const
+    {
+        return yielder.yield(arguments);
+    }
+
+}}}  // namespace puppet::runtime::functions

--- a/lib/src/runtime/operators.cc
+++ b/lib/src/runtime/operators.cc
@@ -110,13 +110,9 @@ namespace puppet { namespace runtime {
         }
 
         // Set the value in the current scope
-        auto value = ctx.current().set(var->name(), std::move(right), get<1>(position));
+        auto value = ctx.current().set(var->name(), std::move(right));
         if (!value) {
-            auto where = ctx.current().where(var->name());
-            if (*where == 0) {
-                throw evaluation_exception(position, (boost::format("cannot assign to $%1%: a fact with the same name exists at this scope.") % var->name()).str());
-            }
-            throw evaluation_exception(position, (boost::format("cannot assign to $%1%: variable was already assigned in the current scope on line %2%.") % var->name() % *where).str());
+            throw evaluation_exception(position, (boost::format("cannot assign to $%1%: variable already exists in the current scope.") % var->name()).str());
         }
         var->update(value);
     }

--- a/lib/src/runtime/value.cc
+++ b/lib/src/runtime/value.cc
@@ -335,6 +335,19 @@ namespace puppet { namespace runtime {
         return result;
     }
 
+    void join(ostream& os, array const& arr, std::string const& separator)
+    {
+        bool first = true;
+        for (auto const& element : arr) {
+            if (first) {
+                first = false;
+            } else {
+                os << separator;
+            }
+            os << element;
+        }
+    }
+
     bool operator==(undef const&, undef const&)
     {
         return true;

--- a/lib/src/runtime/yielder.cc
+++ b/lib/src/runtime/yielder.cc
@@ -1,0 +1,120 @@
+#include <puppet/runtime/yielder.hpp>
+#include <boost/format.hpp>
+
+using namespace std;
+using namespace puppet::lexer;
+
+namespace puppet { namespace runtime {
+
+    yielder::yielder(expression_evaluator& evaluator, token_position const& position, boost::optional<ast::lambda> const& lambda) :
+        _evaluator(evaluator),
+        _position(position),
+        _lambda(lambda)
+    {
+    }
+
+    bool yielder::lambda_given() const
+    {
+        return static_cast<bool>(_lambda);
+    }
+
+    value yielder::yield()
+    {
+        array arguments;
+        return yield(arguments);
+    }
+
+    value yielder::yield(array& arguments)
+    {
+        if (!lambda_given()) {
+            throw evaluation_exception(_position, "function call requires a lambda but one was not given.");
+        }
+
+        unordered_map<string, value> variables;
+        bool has_optional_parameters = false;
+        if (_lambda->parameters()) {
+            for (size_t i = 0; i < _lambda->parameters()->size(); ++i) {
+                auto& parameter = (*_lambda->parameters())[i];
+                auto& variable = parameter.variable();
+                runtime::value value;
+
+                // Check for capture
+                if (parameter.captures()) {
+                    if (i != _lambda->parameters()->size() - 1) {
+                        throw evaluation_exception(parameter.position(), (boost::format("parameter $%1% \"captures rest\" but is not the last parameter.") % variable.name()).str());
+                    }
+                    // Last parameter captures the remainder
+                    if (parameter.default_value()) {
+                        // Check the default value cache
+                        auto it = _default_cache.find(variable.name());
+                        if (it == _default_cache.end()) {
+                            array captured;
+                            captured.emplace_back(_evaluator.evaluate(*parameter.default_value()));
+                            it = _default_cache.emplace(variable.name(), std::move(captured)).first;
+                        }
+                        // Copy the value from the cache
+                        value = it->second;
+                    } else {
+                        array captured;
+                        if (i < arguments.size()) {
+                            captured.reserve(arguments.size() - i);
+                            captured.insert(captured.end(), std::make_move_iterator(arguments.begin() + i), std::make_move_iterator(arguments.end()));
+                        }
+                        value = std::move(captured);
+                    }
+                } else {
+                    if (has_optional_parameters && !parameter.default_value()) {
+                        throw evaluation_exception(parameter.position(), (boost::format("parameter $%1% is required but appears after optional parameters.") % variable.name()).str());
+                    }
+
+                    has_optional_parameters = static_cast<bool>(parameter.default_value());
+
+                    if (i >= arguments.size()) {
+                        // Check for not present and without a default value
+                        if (!parameter.default_value()) {
+                            throw evaluation_exception(parameter.position(), (boost::format("parameter $%1% is required but no value was given.") % variable.name()).str());
+                        }
+
+                        // First check the default value cache
+                        auto it = _default_cache.find(variable.name());
+                        if (it == _default_cache.end()) {
+                            it = _default_cache.emplace(variable.name(), _evaluator.evaluate(*parameter.default_value())).first;
+                        }
+
+                        // Copy the value from the cache
+                        value = it->second;
+                    } else {
+                        // Use the supplied argument
+                        value = std::move(arguments[i]);
+                    }
+                }
+
+                // TODO: verify the value is of the parameter's type
+
+                if (!variables.emplace(variable.name(), std::move(value)).second) {
+                    throw evaluation_exception(parameter.position(), (boost::format("parameter $%1% already exists in the parameter list.") % variable.name()).str());
+                }
+            }
+        }
+
+        // If there's a lambda body, evaluate
+        value result;
+        if (_lambda->body()) {
+            // Create an ephemeral scope
+            ephemeral_scope ephemeral(_evaluator.context());
+            auto& current_scope = _evaluator.context().current();
+
+            // Set the variables
+            for (auto& variable : variables) {
+                current_scope.set(variable.first, std::move(variable.second));
+            }
+
+            // Evaluate the lambda body
+            for (auto& expression : *_lambda->body()) {
+                result = _evaluator.evaluate(expression);
+            }
+        }
+        return result;
+    }
+
+}}  // namespace puppet::runtime

--- a/lib/tests/fixtures/lexer/statement_calls.pp
+++ b/lib/tests/fixtures/lexer/statement_calls.pp
@@ -8,6 +8,6 @@ debug
 info
 notice
 warning
-error
+err
 fail
 import

--- a/lib/tests/lexer/lexer.cc
+++ b/lib/tests/lexer/lexer.cc
@@ -349,7 +349,7 @@ SCENARIO("lexing statement calls")
     require_token(token, end, token_id::statement_call, "info");
     require_token(token, end, token_id::statement_call, "notice");
     require_token(token, end, token_id::statement_call, "warning");
-    require_token(token, end, token_id::statement_call, "error");
+    require_token(token, end, token_id::statement_call, "err");
     require_token(token, end, token_id::statement_call, "fail");
     require_token(token, end, token_id::statement_call, "import");
     REQUIRE(token == end);


### PR DESCRIPTION
Implementing function calls and yielding to lambdas.

The following Puppet functions are now implemented:

* alert
* crit
* debug
* emerg
* err
* fail
* info
* notice
* warning
* with

Lambda parameter type validation is not still unimplemented.

This commit also changes the output format to better match Puppet's.

Additionally, the AST is now "read-only".  This was needed to allow
lambda bodies to be executed more than once.