### PR TITLE
Fix interpolation of variable names with leading underscores.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(puppet SHARED
     src/lexer/token_id.cc
     src/ast/access_expression.cc
     src/ast/array.cc
+    src/ast/bare_word.cc
     src/ast/boolean.cc
     src/ast/case_expression.cc
     src/ast/class_definition_expression.cc

--- a/lib/include/puppet/ast/bare_word.hpp
+++ b/lib/include/puppet/ast/bare_word.hpp
@@ -1,0 +1,61 @@
+/**
+ * @file
+ * Declares the AST bare word.
+ */
+#pragma once
+
+#include "../lexer/token_position.hpp"
+#include <boost/range.hpp>
+#include <iostream>
+#include <string>
+
+namespace puppet { namespace ast {
+
+    /**
+     * Represents an AST bare word.
+     */
+    struct bare_word
+    {
+        /**
+         * Default constructor for bare_word.
+         */
+        bare_word();
+
+        /**
+         * Constructs a bare word from a token.
+         * @tparam Iterator The underlying iterator type for the token.
+         * @param token The token representing the bare word.
+         */
+        template <typename Iterator>
+        explicit bare_word(boost::iterator_range<Iterator> const& token) :
+            _position(token.begin().position()),
+            _value(token.begin(), token.end())
+        {
+        }
+
+        /**
+         * Gets the value of the bare word.
+         * @return Returns the value of the bare word.
+         */
+        std::string const& value() const;
+
+        /**
+         * Gets the position of the bare word.
+         * @return Returns the position of the bare word.
+         */
+        lexer::token_position const& position() const;
+
+    private:
+        lexer::token_position _position;
+        std::string _value;
+    };
+
+    /**
+     * Stream insertion operator for AST bare word.
+     * @param os The output stream to write the bare word to.
+     * @param word The bare word to write.
+     * @return Returns the given output stream.
+     */
+    std::ostream& operator<<(std::ostream& os, bare_word const& word);
+
+}}  // namespace puppet::ast

--- a/lib/include/puppet/ast/expression.hpp
+++ b/lib/include/puppet/ast/expression.hpp
@@ -12,6 +12,7 @@
 #include "variable.hpp"
 #include "type.hpp"
 #include "name.hpp"
+#include "bare_word.hpp"
 #include <boost/variant.hpp>
 #include <iostream>
 #include <vector>
@@ -49,6 +50,7 @@ namespace puppet { namespace ast {
         regex,
         variable,
         name,
+        bare_word,
         ast::type,
         boost::recursive_wrapper<array>,
         boost::recursive_wrapper<hash>

--- a/lib/include/puppet/ast/string.hpp
+++ b/lib/include/puppet/ast/string.hpp
@@ -23,17 +23,6 @@ namespace puppet { namespace ast {
         string();
 
         /**
-         * Constructs a string from a token.
-         * @tparam Iterator The underlying iterator type for the token.
-         * @param range The token representing the string.
-         */
-        template <typename Iterator>
-        explicit string(boost::iterator_range<Iterator> const& range)
-        {
-            throw std::runtime_error("should not be called");
-        }
-
-        /**
          * Constructs a string from a string token.
          * @tparam Iterator The underlying iterator type for the token.
          * @param token The string token to construct the string from.

--- a/lib/include/puppet/parser/grammar.hpp
+++ b/lib/include/puppet/parser/grammar.hpp
@@ -113,15 +113,16 @@ namespace puppet { namespace parser {
             // Basic expressions
             basic_expression =
                 (
-                    undef    |
-                    boolean  |
-                    number   |
-                    string   |
-                    regex    |
-                    variable |
-                    name     |
-                    type     |
-                    array    |
+                    undef     |
+                    boolean   |
+                    number    |
+                    string    |
+                    regex     |
+                    variable  |
+                    name      |
+                    bare_word |
+                    type      |
+                    array     |
                     hash
                 ) [ _val = phx::construct<ast::basic_expression>(_1) ];
             undef =
@@ -132,7 +133,6 @@ namespace puppet { namespace parser {
             number =
                 lexer.number [ _val = phx::construct<ast::number>(_1) ];
             string =
-                token(token_id::bare_word)                                                [ _val = phx::construct<ast::string>(_1) ] |
                 (lexer.single_quoted_string | lexer.double_quoted_string | lexer.heredoc) [ _val = phx::construct<ast::string>(_1) ];
             regex =
                 token(token_id::regex) [ _val = phx::construct<ast::regex>(_1) ];
@@ -140,6 +140,8 @@ namespace puppet { namespace parser {
                 token(token_id::variable) [ _val = phx::construct<ast::variable>(_1) ];
             name =
                 (token(token_id::name) | token(token_id::statement_call)) [ _val = phx::construct<ast::name>(_1) ];
+            bare_word =
+                token(token_id::bare_word) [ _val = phx::construct<ast::bare_word>(_1) ];
             type =
                 token(token_id::type) [ _val = phx::construct<ast::type>(_1) ];
             array =
@@ -344,6 +346,7 @@ namespace puppet { namespace parser {
             regex.name("regex");
             variable.name("variable");
             name.name("name");
+            bare_word.name("bare word");
             type.name("type");
             array.name("array");
             hash.name("hash");
@@ -423,6 +426,7 @@ namespace puppet { namespace parser {
             debug(regex);
             debug(variable);
             debug(name);
+            debug(bare_word);
             debug(type);
             debug(array);
             debug(hash);
@@ -505,6 +509,7 @@ namespace puppet { namespace parser {
         boost::spirit::qi::rule<iterator_type, puppet::ast::regex()> regex;
         boost::spirit::qi::rule<iterator_type, puppet::ast::variable()> variable;
         boost::spirit::qi::rule<iterator_type, puppet::ast::name()> name;
+        boost::spirit::qi::rule<iterator_type, puppet::ast::bare_word()> bare_word;
         boost::spirit::qi::rule<iterator_type, puppet::ast::type()> type;
         boost::spirit::qi::rule<iterator_type, puppet::ast::array()> array;
         boost::spirit::qi::rule<iterator_type, puppet::ast::hash()> hash;

--- a/lib/src/ast/bare_word.cc
+++ b/lib/src/ast/bare_word.cc
@@ -1,0 +1,28 @@
+#include <puppet/ast/bare_word.hpp>
+
+using namespace std;
+using namespace puppet::lexer;
+
+namespace puppet { namespace ast {
+
+    bare_word::bare_word()
+    {
+    }
+
+    string const& bare_word::value() const
+    {
+        return _value;
+    }
+
+    token_position const& bare_word::position() const
+    {
+        return _position;
+    }
+
+    ostream& operator<<(ostream& os, bare_word const& word)
+    {
+        os << word.value();
+        return os;
+    }
+
+}}  // namespace puppet::ast

--- a/lib/src/ast/string.cc
+++ b/lib/src/ast/string.cc
@@ -5,7 +5,11 @@ using namespace puppet::lexer;
 
 namespace puppet { namespace ast {
 
-    string::string()
+    string::string() :
+        _quote(0),
+        _interpolated(false),
+        _margin(0),
+        _remove_break(false)
     {
     }
 

--- a/lib/src/runtime/expression_evaluator.cc
+++ b/lib/src/runtime/expression_evaluator.cc
@@ -109,6 +109,12 @@ namespace puppet { namespace runtime {
             return name.value();
         }
 
+        result_type operator()(ast::bare_word const& word) const
+        {
+            // Treat as a string
+            return word.value();
+        }
+
         result_type operator()(ast::type const& type) const
         {
             auto kind = get_type_kind(type.name());


### PR DESCRIPTION
Fixing string interpolation that should handle the conversion of bare
words (may lead with underscore) into variables.  This fixes
interpolation of ${_foo}, ${_foo[0]} and ${_foo.bar}, where _foo should
be treated as a reference to variable $_foo.

This also fixes the parsing of bare words, which caused an unhandled
exception since string interpolation was implemented.  It also changes
the grammar such that the parser will now output "bare words" into the
AST instead of treating them as strings.  This allows us to handle the
above expressions.

This addresses GH issue #9.