### PR TITLE
Prevent unproductive expression evaluation.

### DIFF
--- a/exe/main.cc
+++ b/exe/main.cc
@@ -41,7 +41,8 @@ int main(int argc, char* argv[])
             });
             expression_evaluator evaluator(ctx);
             for (auto &expression : *manifest.body()) {
-                evaluator.evaluate(expression);
+                // Top level expressions must be productive
+                evaluator.evaluate(expression, true);
             }
         }
 

--- a/lib/include/puppet/runtime/expression_evaluator.hpp
+++ b/lib/include/puppet/runtime/expression_evaluator.hpp
@@ -48,9 +48,10 @@ namespace puppet { namespace runtime {
         /**
          * Evaluates the given AST expression and returns the resulting runtime value.
          * @param expr The AST expression to evaluate.
+         * @param productive True if the expression is required to be productive (i.e. has side effect) or false if not.
          * @return Returns the runtime value that is the result of evaluating the expression.
          */
-        value evaluate(ast::expression const& expr);
+        value evaluate(ast::expression const& expr, bool productive = false);
 
         /**
          * Gets the evaluation context.
@@ -70,8 +71,7 @@ namespace puppet { namespace runtime {
             lexer::token_position& left_position,
             std::uint8_t min_precedence,
             std::vector<ast::binary_expression>::const_iterator& begin,
-            std::vector<ast::binary_expression>::const_iterator const& end
-        );
+            std::vector<ast::binary_expression>::const_iterator const& end);
 
         void evaluate(
             value& left,


### PR DESCRIPTION
This commit makes the expression evaluator behave more like Puppet's
with respect to evaluating unproductive expressions.

For example, '1+1' is an unproductive expression because it doesn't
change the state of the system.  Puppet detects these expressions and
treats them like an error, provided the expression isn't the last in a
block (which functions like a "return value").

This checking is actually more strict than Puppet's.  For example, the
expression '1 + ($a = 1)' is treated as productive by Puppet because the
subexpression $a = 1 is productive.  This implementation considers that
to be an error since the entire expression is unproductive even if the
subexpression is productive.