### PR TITLE
Fix postfix expressions.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(puppet SHARED
     src/ast/node_definition_expression.cc
     src/ast/number.cc
     src/ast/parameter.cc
+    src/ast/postfix_expression.cc
     src/ast/regex.cc
     src/ast/selector_expression.cc
     src/ast/undef.cc

--- a/lib/include/puppet/ast/access_expression.hpp
+++ b/lib/include/puppet/ast/access_expression.hpp
@@ -11,48 +11,6 @@
 namespace puppet { namespace ast {
 
     /**
-     * Represents an AST access.
-     */
-    struct access
-    {
-        /**
-         * Default constructor for access.
-         */
-        access();
-
-        /**
-         * Constructs an access with the given argument expressions.
-         * @param position The position of the access expression.
-         * @param arguments The argument expressions to access.
-         */
-        access(lexer::token_position position, std::vector<expression> arguments);
-
-        /**
-         * Gets the argument expressions.
-         * @return Returns the argument expressions.
-         */
-        std::vector<expression> const& arguments() const;
-
-        /**
-         * Gets the position of the access.
-         * @return Returns the position of the access.
-         */
-        lexer::token_position const& position() const;
-
-     private:
-        lexer::token_position _position;
-        std::vector<expression> _arguments;
-    };
-
-    /**
-     * Stream insertion operator for AST access.
-     * @param os The output stream to write the access to.
-     * @param expr The access to write.
-     * @return Returns the given output stream.
-     */
-    std::ostream& operator<<(std::ostream& os, ast::access const& access);
-
-    /**
      * Represents an AST access expression.
      */
     struct access_expression
@@ -63,23 +21,17 @@ namespace puppet { namespace ast {
         access_expression();
 
         /**
-         * Constructs an access expression with the given original target and subsequent accesses.
-         * @param target The original target the first access is performed on.
-         * @param accesses The access chains; the first is accessed on the target, the remainder on each subsequent return value from the previous access.
+         * Constructs an access expression with the given argument expressions.
+         * @param position The position of the access expression.
+         * @param arguments The argument expressions to access.
          */
-        access_expression(primary_expression target, std::vector<access> accesses);
+        access_expression(lexer::token_position position, std::vector<expression> arguments);
 
         /**
-         * Gets the target expression.
-         * @return Returns the target expression.
+         * Gets the argument expressions.
+         * @return Returns the argument expressions.
          */
-        primary_expression const& target() const;
-
-        /**
-         * Gets the accesses that make up the expression.
-         * @return Returns the accesses in the expression.
-         */
-        std::vector<access> const& accesses() const;
+        std::vector<expression> const& arguments() const;
 
         /**
          * Gets the position of the access expression.
@@ -88,8 +40,8 @@ namespace puppet { namespace ast {
         lexer::token_position const& position() const;
 
     private:
-        primary_expression _target;
-        std::vector<access> _accesses;
+        lexer::token_position _position;
+        std::vector<expression> _arguments;
     };
 
     /**

--- a/lib/include/puppet/ast/expression.hpp
+++ b/lib/include/puppet/ast/expression.hpp
@@ -38,6 +38,7 @@ namespace puppet { namespace ast {
     struct collection_expression;
     struct unary_expression;
     struct access_expression;
+    struct postfix_expression;
     struct expression;
 
     /**
@@ -69,11 +70,9 @@ namespace puppet { namespace ast {
      * Represents a control-flow expression.
      */
     typedef boost::variant<
-        boost::recursive_wrapper<selector_expression>,
         boost::recursive_wrapper<case_expression>,
         boost::recursive_wrapper<if_expression>,
         boost::recursive_wrapper<unless_expression>,
-        boost::recursive_wrapper<method_call_expression>,
         boost::recursive_wrapper<function_call_expression>
     > control_flow_expression;
 
@@ -113,7 +112,7 @@ namespace puppet { namespace ast {
         control_flow_expression,
         catalog_expression,
         boost::recursive_wrapper<unary_expression>,
-        boost::recursive_wrapper<access_expression>,
+        boost::recursive_wrapper<postfix_expression>,
         boost::recursive_wrapper<expression>
     > primary_expression;
 
@@ -381,24 +380,23 @@ namespace puppet { namespace ast {
         expression();
 
         /**
-         * Constructs an expression with the first primary expression and a variable number of binary expressions.
-         * @param first The first primary expression in the expression.
-         * @param remainder The remaining binary expressions; empty if a unary expression.
+         * Constructs an expression.
+         * @param primary The primary expression.
+         * @param binary The binary expressions to apply.
          */
-        explicit expression(primary_expression first, std::vector<binary_expression> remainder = std::vector<binary_expression>());
+        explicit expression(primary_expression primary, std::vector<binary_expression> binary = std::vector<binary_expression>());
 
         /**
-         * Gets the first primary expression in the expression.
-         * @return Returns the first primary expression in the expression.
+         * Gets the primary expression.
+         * @return Returns the primary expression.
          */
-        primary_expression const& first() const;
+        primary_expression const& primary() const;
 
         /**
-         * Gets the remainder of the expression (for binary expressions).
-         * Empty for unary expressions.
-         * @return Returns the remainder of the expression.
+         * Gets the binary expressions.
+         * @return Returns the binary expressions.
          */
-        std::vector<binary_expression> const& remainder() const;
+        std::vector<binary_expression> const& binary() const;
 
         /**
          * Gets the position of the expression.
@@ -413,8 +411,8 @@ namespace puppet { namespace ast {
         bool blank() const;
 
      private:
-        primary_expression _first;
-        std::vector<binary_expression> _remainder;
+        primary_expression _primary;
+        std::vector<binary_expression> _binary;
     };
 
     /**

--- a/lib/include/puppet/ast/expression_def.hpp
+++ b/lib/include/puppet/ast/expression_def.hpp
@@ -23,3 +23,4 @@
 #include "defined_type_expression.hpp"
 #include "node_definition_expression.hpp"
 #include "collection_expression.hpp"
+#include "postfix_expression.hpp"

--- a/lib/include/puppet/ast/method_call_expression.hpp
+++ b/lib/include/puppet/ast/method_call_expression.hpp
@@ -14,22 +14,22 @@
 namespace puppet { namespace ast {
 
     /**
-     * Represents an AST method call.
+     * Represents an AST method call expression.
      */
-    struct method_call
+    struct method_call_expression
     {
         /**
-         * Default constructor for method_call.
+         * Default constructor for method_call_expression.
          */
-        method_call();
+        method_call_expression();
 
         /**
-         * Constructs a method call with the given method name, optional arguments, and optional lambda.
+         * Constructs a method call expression with the given method name, optional arguments, and optional lambda.
          * @param method The name of the method being called.
          * @param arguments The optional arguments to the method.
          * @param lambda The optional lambda to the method.
          */
-        method_call(name method, boost::optional<std::vector<expression>> arguments, boost::optional<struct lambda> lambda);
+        method_call_expression(name method, boost::optional<std::vector<expression>> arguments, boost::optional<struct lambda> lambda);
 
         /**
          * Gets the method name.
@@ -59,54 +59,6 @@ namespace puppet { namespace ast {
         name _method;
         boost::optional<std::vector<expression>> _arguments;
         boost::optional<struct lambda> _lambda;
-    };
-
-    /**
-     * Stream insertion operator for AST method call.
-     * @param os The output stream to write the method call to.
-     * @param call The method call to write.
-     * @return Returns the given output stream.
-     */
-    std::ostream& operator<<(std::ostream& os, method_call const& call);
-
-    /**
-     * Represents an AST method call expression.
-     */
-    struct method_call_expression
-    {
-        /**
-         * Default constructor for method_call_expression.
-         */
-        method_call_expression();
-
-        /**
-         * Constructs a method call expression with the given original target and subsequent calls.
-         * @param target The original target the first method is called on.
-         * @param calls The method call chains; the first is called on the target, the remainder on each subsequent return value.
-         */
-        method_call_expression(primary_expression target, std::vector<method_call> calls);
-
-        /**
-         * Gets the target expression.
-         * @return Returns the target expression.
-         */
-        primary_expression const& target() const;
-
-        /**
-         * Gets the method calls that make up the expression.
-         * @return Returns the method calls in the expression.
-         */
-        std::vector<method_call> const& calls() const;
-
-        /**
-         * Gets the position of the method call expression.
-         * @return Returns the position of the method call expression.
-         */
-        lexer::token_position const& position() const;
-
-     private:
-        primary_expression _target;
-        std::vector<method_call> _calls;
     };
 
     /**

--- a/lib/include/puppet/ast/postfix_expression.hpp
+++ b/lib/include/puppet/ast/postfix_expression.hpp
@@ -1,0 +1,71 @@
+/**
+ * @file
+ * Declares the AST postfix expression.
+ */
+#pragma once
+
+#include "expression.hpp"
+#include "selector_expression.hpp"
+#include "access_expression.hpp"
+#include "method_call_expression.hpp"
+
+namespace puppet { namespace ast {
+
+    /**
+     * Represents a postfix subexpression.
+     */
+    typedef boost::variant<
+        selector_expression,
+        access_expression,
+        method_call_expression
+    > postfix_subexpression;
+
+    /**
+     * Represents a postfix expression.
+     */
+    struct postfix_expression
+    {
+        /**
+         * Default constructor for postfix expression.
+         */
+        postfix_expression();
+
+        /**
+         * Constructs a postfix expression.
+         * @param primary The primary expression.
+         * @param subexpressions The postfix subexpressions to apply.
+         */
+        postfix_expression(primary_expression primary, std::vector<postfix_subexpression> subexpressions);
+
+        /**
+         * Gets the primary expression.
+         * @return Returns the primary expression.
+         */
+        primary_expression const& primary() const;
+
+        /**
+         * Gets the postfix subexpressions.
+         * @return Returns the postfix subexpressions.
+         */
+        std::vector<postfix_subexpression> const& subexpressions() const;
+
+        /**
+         * Gets the position of the postfix expression.
+         * @return Returns the position of the postfix expression.
+         */
+        lexer::token_position const& position() const;
+
+     private:
+        primary_expression _primary;
+        std::vector<postfix_subexpression> _subexpressions;
+    };
+
+    /**
+     * Stream insertion operator for AST postfix expression.
+     * @param os The output stream to write the postfix expression to.
+     * @param expr The selector expression to write.
+     * @return Returns the given output stream.
+     */
+    std::ostream& operator<<(std::ostream& os, postfix_expression const& expr);
+
+}}  // puppet::ast

--- a/lib/include/puppet/ast/resource_expression.hpp
+++ b/lib/include/puppet/ast/resource_expression.hpp
@@ -180,13 +180,13 @@ namespace puppet { namespace ast {
          * @param bodies The resource bodies being defined.
          * @param status The resource status.
          */
-        resource_expression(expression type, std::vector<resource_body> bodies, resource_status status = resource_status::realized);
+        resource_expression(primary_expression type, std::vector<resource_body> bodies, resource_status status = resource_status::realized);
 
         /**
          * Gets the type expression of the resource being defined.
          * @return Returns the type expression of the resource being defined.
          */
-        expression const& type() const;
+        primary_expression const& type() const;
 
         /**
          * Gets the resource bodies that are being defined.
@@ -207,7 +207,7 @@ namespace puppet { namespace ast {
         lexer::token_position const& position() const;
 
      private:
-        expression _type;
+        primary_expression _type;
         std::vector<resource_body> _bodies;
         resource_status _status;
     };

--- a/lib/include/puppet/ast/resource_override_expression.hpp
+++ b/lib/include/puppet/ast/resource_override_expression.hpp
@@ -26,13 +26,13 @@ namespace puppet { namespace ast {
          * @param reference The reference expression for resources being overriden.
          * @param attributes The optional list of attributes being overridden.
          */
-        resource_override_expression(expression reference, boost::optional<std::vector<attribute_expression>> attributes);
+        resource_override_expression(primary_expression reference, boost::optional<std::vector<attribute_expression>> attributes);
 
         /**
          * Gets the reference expression for the resources being overriden.
          * @return Returns the reference expression for the resources being overriden.
          */
-        expression const& reference() const;
+        primary_expression const& reference() const;
 
         /**
          * Gets the optional attributes being overridden.
@@ -47,7 +47,7 @@ namespace puppet { namespace ast {
         lexer::token_position const& position() const;
 
      private:
-        expression _reference;
+        primary_expression _reference;
         boost::optional<std::vector<attribute_expression>> _attributes;
     };
 

--- a/lib/include/puppet/ast/selector_expression.hpp
+++ b/lib/include/puppet/ast/selector_expression.hpp
@@ -44,7 +44,6 @@ namespace puppet { namespace ast {
         lexer::token_position const& position() const;
 
      private:
-        lexer::token_position _position;
         expression _selector;
         expression _result;
     };
@@ -68,17 +67,11 @@ namespace puppet { namespace ast {
         selector_expression();
 
         /**
-         * Constructs a selector expression with the given value expression and cases.
-         * @param value The value being selected upon.
+         * Constructs a selector expression.
+         * @param position The position of the selector expression.
          * @param cases The selector cases.
          */
-        selector_expression(primary_expression value, std::vector<selector_case_expression> cases);
-
-        /**
-         * Gets the value of the selector expression.
-         * @return Returns the value of the selector expression.
-         */
-        primary_expression const& value() const;
+        selector_expression(lexer::token_position position, std::vector<selector_case_expression> cases);
 
         /**
          * Gets the selector case expressions.
@@ -93,7 +86,7 @@ namespace puppet { namespace ast {
         lexer::token_position const& position() const;
 
      private:
-        primary_expression _value;
+        lexer::token_position _position;
         std::vector<selector_case_expression> _cases;
     };
 

--- a/lib/src/ast/access_expression.cc
+++ b/lib/src/ast/access_expression.cc
@@ -4,72 +4,34 @@
 
 using namespace std;
 using namespace puppet::lexer;
-using boost::optional;
 
 namespace puppet { namespace ast {
-
-    access::access()
-    {
-    }
-
-    access::access(token_position position, vector<expression> arguments) :
-        _position(std::move(position)),
-        _arguments(std::move(arguments))
-    {
-    }
-
-    vector<expression> const& access::arguments() const
-    {
-        return _arguments;
-    }
-
-    token_position const& access::position() const
-    {
-        return _position;
-    }
-
-    ostream& operator<<(ostream& os, access const& access)
-    {
-        os << '[';
-        pretty_print(os, access.arguments(), ", ");
-        os << ']';
-        return os;
-    }
 
     access_expression::access_expression()
     {
     }
 
-    access_expression::access_expression(primary_expression target, vector<access> accesses) :
-        _target(std::move(target)),
-        _accesses(std::move(accesses))
+    access_expression::access_expression(token_position position, vector<expression> arguments) :
+        _position(std::move(position)),
+        _arguments(std::move(arguments))
     {
     }
 
-    primary_expression const& access_expression::target() const
+    vector<expression> const& access_expression::arguments() const
     {
-        return _target;
-    }
-
-    vector<access> const& access_expression::accesses() const
-    {
-        return _accesses;
+        return _arguments;
     }
 
     token_position const& access_expression::position() const
     {
-        return get_position(_target);
+        return _position;
     }
 
     ostream& operator<<(ostream& os, access_expression const& expr)
     {
-        if (is_blank(expr.target()) || expr.accesses().empty()) {
-            return os;
-        }
-        os << expr.target();
-        for (auto const& access : expr.accesses()) {
-            os << access;
-        }
+        os << '[';
+        pretty_print(os, expr.arguments(), ", ");
+        os << ']';
         return os;
     }
 

--- a/lib/src/ast/expression.cc
+++ b/lib/src/ast/expression.cc
@@ -12,24 +12,19 @@ namespace puppet { namespace ast {
             return default_position;
         }
 
-        result_type operator()(basic_expression const& expr) const
+        result_type operator()(basic_expression const& subexpression) const
         {
-            return get_position(expr);
+            return get_position(subexpression);
         }
 
-        result_type operator()(control_flow_expression const& expr) const
+        result_type operator()(control_flow_expression const& subexpression) const
         {
-            return get_position(expr);
+            return get_position(subexpression);
         }
 
-        result_type operator()(catalog_expression const& expr) const
+        result_type operator()(catalog_expression const& subexpression) const
         {
-            return get_position(expr);
-        }
-
-        result_type operator()(primary_expression const& expr) const
-        {
-            return get_position(expr);
+            return get_position(subexpression);
         }
 
         template <typename T>
@@ -250,37 +245,37 @@ namespace puppet { namespace ast {
     {
     }
 
-    expression::expression(primary_expression first, vector<binary_expression> remainder) :
-        _first(std::move(first)),
-        _remainder(std::move(remainder))
+    expression::expression(primary_expression primary, vector<binary_expression> binary) :
+        _primary(std::move(primary)),
+        _binary(std::move(binary))
     {
     }
 
-    primary_expression const& expression::first() const
+    primary_expression const& expression::primary() const
     {
-        return _first;
+        return _primary;
     }
 
-    vector<binary_expression> const& expression::remainder() const
+    vector<binary_expression> const& expression::binary() const
     {
-        return _remainder;
+        return _binary;
     }
 
     token_position const& expression::position() const
     {
-        return get_position(_first);
+        return get_position(_primary);
     }
 
     bool expression::blank() const
     {
-        return is_blank(_first);
+        return is_blank(_primary);
     }
 
     ostream& operator<<(ostream& os, expression const& expr)
     {
-        os << "(" << expr.first();
-        for (auto const& bexpr : expr.remainder()) {
-            os << bexpr;
+        os << "(" << expr.primary();
+        for (auto const& binary : expr.binary()) {
+            os << binary;
         }
         os << ")";
         return os;

--- a/lib/src/ast/method_call_expression.cc
+++ b/lib/src/ast/method_call_expression.cc
@@ -8,84 +8,47 @@ using boost::optional;
 
 namespace puppet { namespace ast {
 
-    method_call::method_call()
+    method_call_expression::method_call_expression()
     {
     }
 
-    method_call::method_call(name method, optional<vector<expression>> arguments, optional<struct lambda> lambda) :
+    method_call_expression::method_call_expression(name method, optional<vector<expression>> arguments, optional<struct lambda> lambda) :
         _method(std::move(method)),
         _arguments(std::move(arguments)),
         _lambda(std::move(lambda))
     {
     }
 
-    name const& method_call::method() const
+    name const& method_call_expression::method() const
     {
         return _method;
     }
 
-    optional<vector<expression>> const& method_call::arguments() const
+    optional<vector<expression>> const& method_call_expression::arguments() const
     {
         return _arguments;
     }
 
-    optional<lambda> const& method_call::lambda() const
+    optional<lambda> const& method_call_expression::lambda() const
     {
         return _lambda;
     }
 
-    token_position const& method_call::position() const
+    token_position const& method_call_expression::position() const
     {
         return _method.position();
     }
 
-    ostream& operator<<(ostream& os, method_call const& call)
-    {
-        if (call.method().value().empty()) {
-            return os;
-        }
-        os << "." << call.method() << "(";
-        pretty_print(os, call.arguments(), ", ");
-        os << ")";
-        if (call.lambda()) {
-            os << " " << *call.lambda();
-        }
-        return os;
-    }
-
-    method_call_expression::method_call_expression()
-    {
-    }
-
-    method_call_expression::method_call_expression(primary_expression target, vector<method_call> calls) :
-        _target(std::move(target)),
-        _calls(std::move(calls))
-    {
-    }
-
-    primary_expression const& method_call_expression::target() const
-    {
-        return _target;
-    }
-
-    vector<method_call> const& method_call_expression::calls() const
-    {
-        return _calls;
-    }
-
-    token_position const& method_call_expression::position() const
-    {
-        return get_position(_target);
-    }
-
     ostream& operator<<(ostream& os, method_call_expression const& expr)
     {
-        if (is_blank(expr.target()) || expr.calls().empty()) {
+        if (expr.method().value().empty()) {
             return os;
         }
-        os << expr.target();
-        for (auto const& call : expr.calls()) {
-            os << call;
+        os << "." << expr.method() << "(";
+        pretty_print(os, expr.arguments(), ", ");
+        os << ")";
+        if (expr.lambda()) {
+            os << " " << *expr.lambda();
         }
         return os;
     }

--- a/lib/src/ast/parameter.cc
+++ b/lib/src/ast/parameter.cc
@@ -43,9 +43,6 @@ namespace puppet { namespace ast {
 
     token_position const& parameter::position() const
     {
-        if (_type) {
-            return get_position(*_type);
-        }
         return _variable.position();
     }
 

--- a/lib/src/ast/postfix_expression.cc
+++ b/lib/src/ast/postfix_expression.cc
@@ -1,0 +1,44 @@
+#include <puppet/ast/postfix_expression.hpp>
+#include <puppet/ast/expression_def.hpp>
+#include <puppet/ast/utility.hpp>
+
+using namespace std;
+using namespace puppet::lexer;
+
+namespace puppet { namespace ast {
+
+    postfix_expression::postfix_expression()
+    {
+    }
+
+    postfix_expression::postfix_expression(primary_expression primary, vector<postfix_subexpression> subexpressions) :
+        _primary(std::move(primary)),
+        _subexpressions(std::move(subexpressions))
+    {
+    }
+
+    primary_expression const& postfix_expression::primary() const
+    {
+        return _primary;
+    }
+
+    vector<postfix_subexpression> const& postfix_expression::subexpressions() const
+    {
+        return _subexpressions;
+    }
+
+    token_position const& postfix_expression::position() const
+    {
+        return get_position(_primary);
+    }
+
+    ostream& operator<<(ostream& os, postfix_expression const& expr)
+    {
+        os << expr.primary();
+        for (auto const& subexpression : expr.subexpressions()) {
+            os << subexpression;
+        }
+        return os;
+    }
+
+}}  // namespace puppet::ast

--- a/lib/src/ast/resource_expression.cc
+++ b/lib/src/ast/resource_expression.cc
@@ -110,14 +110,14 @@ namespace puppet { namespace ast {
     {
     }
 
-    resource_expression::resource_expression(expression type, vector<resource_body> bodies, resource_status status) :
+    resource_expression::resource_expression(primary_expression type, vector<resource_body> bodies, resource_status status) :
         _type(std::move(type)),
         _bodies(std::move(bodies)),
         _status(status)
     {
     }
 
-    expression const& resource_expression::type() const
+    primary_expression const& resource_expression::type() const
     {
         return _type;
     }
@@ -134,7 +134,7 @@ namespace puppet { namespace ast {
 
     token_position const& resource_expression::position() const
     {
-        return _type.position();
+        return get_position(_type);
     }
 
     ostream& operator<<(ostream& os, resource_expression const& expression)

--- a/lib/src/ast/resource_override_expression.cc
+++ b/lib/src/ast/resource_override_expression.cc
@@ -11,13 +11,13 @@ namespace puppet { namespace ast {
     {
     }
 
-    resource_override_expression::resource_override_expression(expression reference, optional<vector<attribute_expression>> attributes) :
+    resource_override_expression::resource_override_expression(primary_expression reference, optional<vector<attribute_expression>> attributes) :
         _reference(std::move(reference)),
         _attributes(std::move(attributes))
     {
     }
 
-    expression const& resource_override_expression::reference() const
+    primary_expression const& resource_override_expression::reference() const
     {
         return _reference;
     }
@@ -29,12 +29,12 @@ namespace puppet { namespace ast {
 
     token_position const& resource_override_expression::position() const
     {
-        return _reference.position();
+        return get_position(_reference);
     }
 
     ostream& operator<<(ostream& os, resource_override_expression const& expr)
     {
-        if (expr.reference().blank()) {
+        if (is_blank(expr.reference())) {
             return os;
         }
         os << expr.reference() << " { ";

--- a/lib/src/ast/selector_expression.cc
+++ b/lib/src/ast/selector_expression.cc
@@ -12,7 +12,6 @@ namespace puppet { namespace ast {
     }
 
     selector_case_expression::selector_case_expression(expression selector, expression result) :
-        _position(selector.position()),
         _selector(std::move(selector)),
         _result(std::move(result))
     {
@@ -30,7 +29,7 @@ namespace puppet { namespace ast {
 
     token_position const& selector_case_expression::position() const
     {
-        return _position;
+        return _selector.position();
     }
 
     ostream& operator<<(ostream& os, selector_case_expression const& expr)
@@ -43,15 +42,10 @@ namespace puppet { namespace ast {
     {
     }
 
-    selector_expression::selector_expression(primary_expression value, vector<selector_case_expression> cases) :
-        _value(std::move(value)),
+    selector_expression::selector_expression(token_position position, vector<selector_case_expression> cases) :
+        _position(std::move(position)),
         _cases(std::move(cases))
     {
-    }
-
-    primary_expression const& selector_expression::value() const
-    {
-        return _value;
     }
 
     vector<selector_case_expression> const& selector_expression::cases() const
@@ -61,12 +55,12 @@ namespace puppet { namespace ast {
 
     token_position const& selector_expression::position() const
     {
-        return get_position(_value);
+        return _position;
     }
 
     ostream& operator<<(ostream& os, selector_expression const& expr)
     {
-        os << expr.value() << " ? { ";
+        os << " ? { ";
         pretty_print(os, expr.cases(), ", ");
         os << " }";
         return os;

--- a/lib/src/runtime/functions/assert_type.cc
+++ b/lib/src/runtime/functions/assert_type.cc
@@ -9,7 +9,7 @@ namespace puppet { namespace runtime { namespace functions {
 
     value assert_type::operator()(call_context& context) const
     {
-        // Check the argument ocunt
+        // Check the argument count
         auto& arguments = context.arguments();
         if (arguments.size() != 2) {
             throw evaluation_exception(arguments.size() > 2 ? context.position(2) : context.position(), (boost::format("expected 2 arguments to assert_type function but %1% were given.") % arguments.size()).str());


### PR DESCRIPTION
Previously the grammar was defined such that postfix expressions could
only chain with expressions of the same type.

For example, access expressions could only chain together with other
access expressions.  So `$a[0][0]` was a valid expression, but `$a.with
|$x| { $x }[0]` was not.

This fixes the grammar such that postfix expressions are primary
expressions that have an initial primary expression and then N number of
postfix expressions that are evaluated in sequence, chained together.

This also fixes a bug in lambdas such that lambdas returning a match or
parameter variable (i.e. a variable in an ephemeral scope) failed to
copy the value into the return value.  This resulted in undefined
behavior when the variable was later accessed.