### PR TITLE
Fix token position assignment in grammar.

### DIFF
--- a/lib/include/puppet/compiler/token_pos.hpp
+++ b/lib/include/puppet/compiler/token_pos.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../lexer/position.hpp"
+#include "../lexer/lexer.hpp"
 #include <boost/spirit/include/qi_parse.hpp>
 
 namespace puppet { namespace compiler {
@@ -73,7 +74,7 @@ namespace puppet { namespace compiler {
 
             if (first != last) {
                 if (static_cast<typename Iterator::value_type::id_type>(_id) == first->id()) {
-                    //attr = first.position();
+                    attr = boost::apply_visitor(lexer::token_position_visitor(), first->value());
                     ++first;
                     return true;
                 }


### PR DESCRIPTION
Accidentally checked in a comment where some functional code should have
been when I removed the phoenix function in favor of a `token_pos`
parser.

This fixes the parser so that it returns non-default contrusted token
positions.