### PR TITLE
Implement class definition expressions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Expression evaluator status:
 * [ ] virtual resource expressions
 * [ ] exported resource expressions
 * [ ] resource defaults expressions
-* [ ] resource override expressions (partial: scope check and `+>` not yet implemented)
-* [ ] class definition expressions
+* [ ] resource override expressions (NYI: scope check and `+>`)
+* [ ] class definition expressions (NYI: ability to declare classes)
 * [ ] defined type expressions
 * [ ] node type expressions
 * [ ] collection expressions

--- a/lib/include/puppet/runtime/context.hpp
+++ b/lib/include/puppet/runtime/context.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "../lexer/position.hpp"
+#include "../ast/syntax_tree.hpp"
 #include "../compiler/node.hpp"
 #include "../logging/logger.hpp"
 #include "scope.hpp"
@@ -15,6 +16,60 @@
 #include <functional>
 
 namespace puppet { namespace runtime {
+
+    /**
+     * Represents a class definition used in evaluation.
+     */
+    struct class_definition
+    {
+        /**
+         * Constructs a class definition.
+         * @param tree The syntax tree containing the class definition expression.
+         * @param expression The class definition expression.
+         */
+        class_definition(std::shared_ptr<ast::syntax_tree> tree, ast::class_definition_expression const* expression);
+
+        /**
+         * Determines if the class has been evaluated.
+         * @return Returns true if the class has been evaluated or false if it has not.
+         */
+        bool evaluated() const;
+
+        /**
+         * Gets the syntax tree containing the class definition expression.
+         * @return Returns the syntax tree containing the class definition expression or nullptr if the class was evaluated.
+         */
+        ast::syntax_tree const* tree() const;
+
+        /**
+         * Gets the class definition expression.
+         * @return Returns the class definition expression or nullptr if the class was evaluated.
+         */
+        ast::class_definition_expression const* expression() const;
+
+        /**
+         * Gets the path of the file containing the class definition.
+         * @return Returns the path of the file containing the class definition.
+         */
+        std::string const& path() const;
+
+        /**
+         * Gets the line number of the class definition.
+         * @return Returns the line number of the class definition.
+         */
+        size_t line() const;
+
+        /**
+         * Releases resources after the definition has been evaluated.
+         */
+        void release();
+
+     private:
+        std::shared_ptr<ast::syntax_tree> _tree;
+        ast::class_definition_expression const* _expression;
+        std::string _path;
+        size_t _line;
+    };
 
     /**
      * Represents the evaluation context.
@@ -91,13 +146,12 @@ namespace puppet { namespace runtime {
         runtime::scope const& top() const;
 
         /**
-         * Adds a scope with the given name.
+         * Adds a scope to the evaluation context.
          * Note: if a scope of the same name already exists, the existing scope is returned unmodified.
-         * @param name The name of the scope to add.
          * @param scope The scope to add.
-         * @return Returns the scope.
+         * @return Returns the scope that was added.
          */
-        runtime::scope* add_scope(std::string name, runtime::scope scope);
+        runtime::scope* add_scope(runtime::scope scope);
 
         /**
          * Finds a scope by name.
@@ -119,18 +173,49 @@ namespace puppet { namespace runtime {
         bool pop_scope();
 
         /**
+         * Looks up a variable.
+         * @param name The name of the variable to look up.
+         * @param position The position where the lookup is taking place or nullptr if not in source.
+         * @return Returns a pointer to the variable if found or nullptr if the variable was not found.
+         */
+        values::value const* lookup(std::string const& name, lexer::position const* position = nullptr);
+
+        /**
          * Emits a warning with the given position and message.
          * @param position The position of the warning.
          * @param message The warning message.
          */
         void warn(lexer::position const& position, std::string const& message) const;
 
-    private:
+        /**
+         * Defines a class in the evaluation context.
+         * @param tree The abstract syntax tree containing the class definition.
+         * @param expression The class definition expression.
+         * @return Returns the new class definition or nullptr if the class already exists in the catalog.
+         */
+        class_definition* define_class(std::shared_ptr<ast::syntax_tree> tree, ast::class_definition_expression const& expression);
+
+        /**
+         * Finds a class definition.
+         * @param name The name of the class to find.
+         * @return Returns the class definition or nullptr if the class does not exist.
+         */
+        class_definition* find_class(std::string const& name);
+
+        /**
+         * Finds a class definition.
+         * @param name The name of the class to find.
+         * @return Returns the class definition or nullptr if the class does not exist.
+         */
+        class_definition const* find_class(std::string const& name) const;
+
+     private:
         logging::logger& _logger;
         compiler::node& _node;
         runtime::catalog& _catalog;
         std::unordered_map<std::string, runtime::scope> _scopes;
         std::deque<runtime::scope*> _scope_stack;
+        std::unordered_map<std::string, class_definition> _classes;
         std::function<void(lexer::position const&, std::string const&)> const& _warn;
     };
 

--- a/lib/include/puppet/runtime/scope.hpp
+++ b/lib/include/puppet/runtime/scope.hpp
@@ -22,10 +22,16 @@ namespace puppet { namespace runtime {
     {
         /**
          * Constructs a scope.
-         * @param name The name of the scope; empty for ephemeral scopes.
+         * @param name The name of the scope (e.g. foo).
+         * @param display_name The display name of the scope (e.g. Class[Foo]).
          * @param parent The parent scope.
          */
-        explicit scope(std::string name = std::string(), scope* parent = nullptr);
+        explicit scope(std::string name, std::string display_name, scope* parent = nullptr);
+
+        /**
+         * Constructs an ephemeral scope.
+         */
+        explicit scope(scope* parent);
 
         /**
          * Determines if the scope is ephemeral.
@@ -41,6 +47,20 @@ namespace puppet { namespace runtime {
         std::string const& name() const;
 
         /**
+         * Gets the display name of the scope.
+         * Note: for ephemeral scopes, this returns the display name of the parent scope.
+         * @return Returns the display name of scope.
+         */
+        std::string const& display_name() const;
+
+        /**
+         * Qualifies the given name using the scope's name.
+         * @param name The name to qualify.
+         * @return Returns the fully-qualified name.
+         */
+        std::string qualify(std::string const& name) const;
+
+        /**
          * Sets a variable in the scope.
          * @param name The name of the variable.
          * @param val The value of the variable.
@@ -52,7 +72,7 @@ namespace puppet { namespace runtime {
         /**
          * Gets a variable in the scope.
          * @param name The name of the variable to get.
-         * @return Returns the tuple of path, line, and value for the variable.
+         * @return Returns the value of the variable or nullptr if not found.
          */
         values::value const* get(std::string const& name) const;
 
@@ -95,6 +115,7 @@ namespace puppet { namespace runtime {
 
      private:
         std::string _name;
+        std::string _display_name;
         scope* _parent;
         std::unordered_map<std::string, std::tuple<values::value, size_t>> _variables;
         std::deque<std::vector<values::value>> _matches;

--- a/lib/include/puppet/runtime/types/class.hpp
+++ b/lib/include/puppet/runtime/types/class.hpp
@@ -26,6 +26,7 @@ namespace puppet { namespace runtime { namespace types {
         explicit basic_class(std::string title = {}) :
             _title(rvalue_cast(title))
         {
+            boost::to_lower(_title);
         }
 
         /**

--- a/lib/include/puppet/runtime/types/resource.hpp
+++ b/lib/include/puppet/runtime/types/resource.hpp
@@ -34,6 +34,9 @@ namespace puppet { namespace runtime { namespace types {
             // Now uppercase every start of a type name
             boost::split_iterator<std::string::iterator> end;
             for (auto it = boost::make_split_iterator(_type_name, boost::first_finder("::", boost::is_equal())); it != end; ++it) {
+                if (!*it) {
+                    continue;
+                }
                 auto range = boost::make_iterator_range(it->begin(), it->begin() + 1);
                 boost::to_upper(range);
             }

--- a/lib/src/runtime/context.cc
+++ b/lib/src/runtime/context.cc
@@ -1,8 +1,49 @@
 #include <puppet/runtime/context.hpp>
+#include <puppet/cast.hpp>
 
 using namespace std;
 
 namespace puppet { namespace runtime {
+
+    class_definition::class_definition(shared_ptr<ast::syntax_tree> tree, ast::class_definition_expression const* expression) :
+        _tree(rvalue_cast(tree)),
+        _expression(expression),
+        _line(expression->position().line())
+    {
+    }
+
+    bool class_definition::evaluated() const
+    {
+        return _expression == nullptr;
+    }
+
+    ast::syntax_tree const* class_definition::tree() const
+    {
+        return _tree.get();
+    }
+
+    ast::class_definition_expression const* class_definition::expression() const
+    {
+        return _expression;
+    }
+
+    string const& class_definition::path() const
+    {
+        return _tree ? _tree->path() : _path;
+    }
+
+    size_t class_definition::line() const
+    {
+        return _line;
+    }
+
+    void class_definition::release()
+    {
+        // Copy the path for later use
+        _path = _tree->path();
+        _expression = nullptr;
+        _tree.reset();
+    }
 
     context::context(logging::logger& logger, compiler::node& node, runtime::catalog& catalog, function<void(lexer::position const&, string const&)> const& warning) :
         _logger(logger),
@@ -11,7 +52,7 @@ namespace puppet { namespace runtime {
         _warn(warning)
     {
         // Add the top scope
-        push_scope(*add_scope("", runtime::scope("Class[main]")));
+        push_scope(*add_scope(runtime::scope("", "Class[main]")));
     }
 
     logging::logger& context::logger()
@@ -64,9 +105,9 @@ namespace puppet { namespace runtime {
         return *_scope_stack.front();
     }
 
-    runtime::scope* context::add_scope(string name, runtime::scope scope)
+    runtime::scope* context::add_scope(runtime::scope scope)
     {
-        return &_scopes.emplace(make_pair(rvalue_cast(name), rvalue_cast(scope))).first->second;
+        return &_scopes.emplace(make_pair(scope.name(), rvalue_cast(scope))).first->second;
     }
 
     runtime::scope* context::find_scope(string const& name)
@@ -93,6 +134,42 @@ namespace puppet { namespace runtime {
         return true;
     }
 
+    values::value const* context::lookup(std::string const& name, lexer::position const* position)
+    {
+        // Look for the last :: delimiter
+        // If not found, use the current scope
+        auto pos = name.rfind("::");
+        if (pos == string::npos) {
+            return this->scope().get(name);
+        }
+
+        // Split into namespace and variable name
+        auto ns = name.substr(0, pos);
+        auto var = name.substr(pos + 2);
+
+        // An empty namespace is the top scope
+        if (ns.empty()) {
+            return top().get(var);
+        }
+
+        // Lookup the namespace
+        auto scope = find_scope(ns);
+        if (scope) {
+            return scope->get(var);
+        }
+
+        // Warn if the scope was not found
+        if (position) {
+            auto definition = find_class(ns);
+            if (!definition) {
+                warn(*position, (boost::format("could not look up variable $%1% because class '%2%' is not defined.") % name % ns).str());
+            } else if (!definition->evaluated()) {
+                warn(*position, (boost::format("could not look up variable $%1% because class '%2%' has not been declared.") % name % ns).str());
+            }
+        }
+        return nullptr;
+    }
+
     void context::warn(lexer::position const& position, string const& message) const
     {
         if (!_warn) {
@@ -101,9 +178,37 @@ namespace puppet { namespace runtime {
         _warn(position, message);
     }
 
+    class_definition* context::define_class(shared_ptr<ast::syntax_tree> tree, ast::class_definition_expression const& expression)
+    {
+        // Add a new resource
+        auto result = _classes.emplace(make_pair(expression.name().value(), class_definition(tree, &expression)));
+        if (!result.second) {
+            return nullptr;
+        }
+        return &result.first->second;
+    }
+
+    class_definition* context::find_class(string const& name)
+    {
+        auto klass = _classes.find(name);
+        if (klass == _classes.end()) {
+            return nullptr;
+        }
+        return &klass->second;
+    }
+
+    class_definition const* context::find_class(string const& name) const
+    {
+        auto klass = _classes.find(name);
+        if (klass == _classes.end()) {
+            return nullptr;
+        }
+        return &klass->second;
+    }
+
     ephemeral_scope::ephemeral_scope(runtime::context& context) :
         _context(context),
-        _scope(string(), &context.scope())
+        _scope(&context.scope())
     {
         _context.push_scope(_scope);
     }

--- a/lib/src/runtime/evaluators/basic.cc
+++ b/lib/src/runtime/evaluators/basic.cc
@@ -70,7 +70,6 @@ namespace puppet { namespace runtime { namespace evaluators {
         static const std::regex match_variable_patterh("^\\d+$");
 
         auto& name = var.name();
-        auto& scope = _evaluator.context().scope();
 
         bool match = false;
         value const* val = nullptr;
@@ -80,10 +79,10 @@ namespace puppet { namespace runtime { namespace evaluators {
                 throw evaluation_exception(var.position(), (boost::format("variable name $%1% is not a valid match variable name.") % var.name()).str());
             }
             // Look up the match
-            val = scope.get(stoi(name));
+            val = _evaluator.context().scope().get(stoi(name));
             match = true;
         } else {
-            val = scope.get(name);
+            val = _evaluator.context().lookup(name, &var.position());
         }
         return variable(name, val, match);
     }
@@ -108,7 +107,6 @@ namespace puppet { namespace runtime { namespace evaluators {
             { types::boolean::name(),       types::boolean() },
             { types::callable::name(),      types::callable() },
             { types::catalog_entry::name(), types::catalog_entry() },
-            { types::klass::name(),         types::klass() },
             { types::collection::name(),    types::collection() },
             { types::data::name(),          types::data() },
             { types::defaulted::name(),     types::defaulted() },

--- a/lib/src/runtime/functions/split.cc
+++ b/lib/src/runtime/functions/split.cc
@@ -22,6 +22,9 @@ namespace puppet { namespace runtime { namespace functions {
             values::array result;
             boost::split_iterator<string::const_iterator> end;
             for (auto it = boost::make_split_iterator(first, boost::first_finder(second, boost::is_equal())); it != end; ++it) {
+                if (!*it) {
+                    continue;
+                }
                 result.emplace_back(boost::copy_range<string>(*it));
             }
             return result;

--- a/lib/src/runtime/values/value.cc
+++ b/lib/src/runtime/values/value.cc
@@ -144,9 +144,9 @@ namespace puppet { namespace runtime { namespace values {
             return types::regexp();
         }
 
-        result_type operator()(type const&) const
+        result_type operator()(type const& t) const
         {
-            return types::type();
+            return t;
         }
 
         result_type operator()(variable const& var) const


### PR DESCRIPTION
Initial support for class definition expressions.  This does the
following:

* If the class derives from another, ensures the parent class has been
  defined.
* Ensures the class hasn't previously been defined.
* Saves the class definition in the evaluation context.

Resource declarations for classes and declaration functions are
forthcoming.

This also fixes scope lookup for variables so that qualified names are
properly respected.