### PR TITLE
Implementing class declaration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,17 @@ Expression evaluator status:
 * [ ] exported resource expressions
 * [ ] resource defaults expressions
 * [ ] resource override expressions (NYI: scope check and `+>`)
-* [ ] class definition expressions (NYI: ability to declare classes)
+* [x] class definition expressions
 * [ ] defined type expressions
-* [ ] node type expressions
+* [ ] node definition expressions
 * [ ] collection expressions
+* [ ] loading files from modules
 * [x] access expressions
 * [x] global scope
-* [ ] local scope
+* [x] local scope
 * [ ] node scope
 * [x] string interpolation
+* [ ] external data lookups (i.e. hiera)
 * [ ] EPP support
 
 Type system implemented:
@@ -124,7 +126,7 @@ Puppet functions implemented:
 * [ ] hiera_array
 * [ ] hiera_hash
 * [ ] hiera_include
-* [ ] include
+* [x] include
 * [x] info
 * [ ] inline_epp
 * [ ] inline_template

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(puppet SHARED
     src/lexer/position.cc
     src/lexer/token_id.cc
     src/logging/logger.cc
+    src/compiler/context.cc
     src/compiler/environment.cc
     src/compiler/node.cc
     src/compiler/parser.cc
@@ -64,6 +65,7 @@ add_library(puppet SHARED
     src/runtime/functions/each.cc
     src/runtime/functions/fail.cc
     src/runtime/functions/filter.cc
+    src/runtime/functions/include.cc
     src/runtime/functions/logging.cc
     src/runtime/functions/split.cc
     src/runtime/functions/with.cc
@@ -114,6 +116,7 @@ add_library(puppet SHARED
     src/runtime/values/value.cc
     src/runtime/catalog.cc
     src/runtime/context.cc
+    src/runtime/definition_scanner.cc
     src/runtime/dispatcher.cc
     src/runtime/executor.cc
     src/runtime/expression_evaluator.cc

--- a/lib/include/puppet/ast/name.hpp
+++ b/lib/include/puppet/ast/name.hpp
@@ -22,6 +22,13 @@ namespace puppet { namespace ast {
         name();
 
         /**
+         * Constructs an AST name with the given position and value.
+         * @param position The position of the name.
+         * @param value The value of the name.
+         */
+        name(lexer::position position, std::string value);
+
+        /**
          * Constructs a name from a token.
          * @tparam Iterator The underlying iterator type for the token.
          * @param token The token representing the name.
@@ -51,6 +58,14 @@ namespace puppet { namespace ast {
     };
 
     /**
+     * Equality operator for AST name.
+     * @param left The left operand.
+     * @param right The right operand.
+     * @return Returns true if the two names are equal or false if they are not equal.
+     */
+    bool operator==(ast::name const& left, ast::name const& right);
+
+    /**
      * Stream insertion operator for AST name.
      * @param os The output stream to write the name to.
      * @param name The name to write.
@@ -59,3 +74,33 @@ namespace puppet { namespace ast {
     std::ostream& operator<<(std::ostream& os, name const& name);
 
 }}  // namespace puppet::ast
+
+namespace std
+{
+    /**
+     * Responsible for hashing AST name.
+     */
+    template<>
+    struct hash<puppet::ast::name>
+    {
+        /**
+         * The argument type.
+         */
+        typedef puppet::ast::name argument_type;
+        /**
+         * The result type of the hash.
+         */
+        typedef std::hash<std::string>::result_type result_type;
+
+        /**
+         * Responsible for hashing the argument.
+         * @param arg The argument to hash.
+         * @return Returns the hash value.
+         */
+        result_type operator()(argument_type const& arg) const
+        {
+            std::hash<std::string> hasher;
+            return hasher(arg.value());
+        }
+    };
+}

--- a/lib/include/puppet/ast/syntax_tree.hpp
+++ b/lib/include/puppet/ast/syntax_tree.hpp
@@ -24,17 +24,10 @@ namespace puppet { namespace ast {
 
         /**
          * Constructs a syntax tree with the given optional list of expressions that comprise the body.
-         * @param path The path of the file that was parsed.
          * @param body The body of the syntax tree.
          * @param end The ending token position for the syntax tree (applicable to interpolation).
          */
-        syntax_tree(std::string path, boost::optional<std::vector<expression>> body, lexer::position end = lexer::position());
-
-        /**
-        * Gets the path to the file that was parsed.
-        * @return Returns the path to the file that was pared.
-        */
-        std::string const& path() const;
+        explicit syntax_tree(boost::optional<std::vector<expression>> body, lexer::position end = lexer::position());
 
         /**
          * Gets the expressions that make up the body of the syntax tree.
@@ -49,7 +42,6 @@ namespace puppet { namespace ast {
         lexer::position const& end() const;
 
     private:
-        std::string _path;
         boost::optional<std::vector<expression>> _body;
         lexer::position _end;
     };

--- a/lib/include/puppet/compiler/context.hpp
+++ b/lib/include/puppet/compiler/context.hpp
@@ -1,0 +1,78 @@
+/**
+ * @file
+ * Declares the compilation context.
+ */
+#pragma once
+
+#include "node.hpp"
+#include "../logging/logger.hpp"
+#include "../lexer/position.hpp"
+#include "../ast/syntax_tree.hpp"
+#include <string>
+#include <fstream>
+#include <memory>
+
+namespace puppet { namespace compiler {
+
+    /**
+     * Represents a compilation context.
+     */
+    struct context
+    {
+        /**
+         * Constructs a compilation context.
+         * @param logger The logger to use during compilation.
+         * @param path The path to the file being compiled.
+         * @param node The node the file is being compiled for.
+         */
+        context(logging::logger& logger, std::shared_ptr<std::string> path, compiler::node& node);
+
+        /**
+         * Gets the logger used for logging messages.
+         * @return Returns the logger used for logging messages.
+         */
+        logging::logger& logger();
+
+        /**
+         * Gets the path of the file being compiled.
+         * @return Returns the path of the file being compiled.
+         */
+        std::shared_ptr<std::string> const& path() const;
+
+        /**
+         * Gets the syntax tree that was parsed.
+         * @return Returns the syntax tree that was parsed.
+         */
+        ast::syntax_tree const& tree() const;
+
+        /**
+         * Gets the current compilation node.
+         * @return Returns the current compilation node.
+         */
+        compiler::node& node();
+
+        /**
+         * Writes a message to the log with the given position.
+         * @param level The logging level.
+         * @param position The position of the message.
+         * @param message The message.
+         */
+        void log(logging::level level, lexer::position const& position, std::string const& message);
+
+        /**
+         * Creates a compilation exception for the given position and message.
+         * @param position The position of the error.
+         * @param message The error message.
+         * @return Returns a compilation exception for the given position and message.
+         */
+        compilation_exception create_exception(lexer::position const& position, std::string const& message);
+
+     private:
+        logging::logger& _logger;
+        std::ifstream _stream;
+        std::shared_ptr<std::string> _path;
+        ast::syntax_tree _tree;
+        compiler::node& _node;
+    };
+
+}}  // puppet::compiler

--- a/lib/include/puppet/compiler/grammar.hpp
+++ b/lib/include/puppet/compiler/grammar.hpp
@@ -30,10 +30,9 @@ namespace puppet { namespace compiler {
         /**
          * Constructs a Puppet language grammar for the given lexer.
          * @param lexer The lexer to use for token definitions.
-         * @param path The path to the file being parsed.
          * @param interpolation True if the grammar is being used for string interpolation or false if not.
          */
-        grammar(Lexer const& lexer, std::string const& path, bool interpolation = false) :
+        grammar(Lexer const& lexer, bool interpolation = false) :
             boost::spirit::qi::grammar<iterator_type, puppet::ast::syntax_tree()>(syntax_tree)
         {
             using namespace boost::spirit::qi;
@@ -44,10 +43,10 @@ namespace puppet { namespace compiler {
             // For string interpolation, end at the first '}' token that isn't part of the grammar
             if (interpolation) {
                 syntax_tree =
-                    (raw_token('{') > statements > token_pos('}')) [_val = phx::construct<ast::syntax_tree>(phx::ref(path), _1, _2)];
+                    (raw_token('{') > statements > token_pos('}')) [_val = phx::construct<ast::syntax_tree>(_1, _2)];
             } else {
                 syntax_tree =
-                    statements [ _val = phx::construct<ast::syntax_tree>(phx::ref(path), _1) ];
+                    statements [ _val = phx::construct<ast::syntax_tree>(_1) ];
             }
 
             // Statements

--- a/lib/include/puppet/compiler/parser.hpp
+++ b/lib/include/puppet/compiler/parser.hpp
@@ -10,7 +10,6 @@
 #include <boost/optional.hpp>
 #include <sstream>
 #include <iomanip>
-#include <memory>
 
 namespace puppet { namespace compiler {
 
@@ -46,25 +45,25 @@ namespace puppet { namespace compiler {
          * @param path The path to the file to parse.
          * @param input The input file to parse.
          * @param interpolation True if parsing for string interpolation or false if not.
-         * @return Returns the syntax tree if parsing succeeds throws parse_exception if not.
+         * @return Returns the parsed syntax tree.
          */
-        static std::shared_ptr<ast::syntax_tree> parse(std::string const& path, std::ifstream& input, bool interpolation = false);
+        static ast::syntax_tree parse(std::string const& path, std::ifstream& input, bool interpolation = false);
         /**
          * Parses the given string into a syntax tree.
          * @param input The input string to parse.
          * @param interpolation True if parsing for string interpolation or false if not.
-         * @return Returns the syntax tree if parsing succeeds throws parse_exception if not.
+         * @return Returns the parsed syntax tree.
          */
-        static std::shared_ptr<ast::syntax_tree> parse(std::string const& input, bool interpolation = false);
+        static ast::syntax_tree parse(std::string const& input, bool interpolation = false);
 
         /**
          * Parses the given iterator range into a syntax tree.
          * @param begin The beginning of the input.
          * @param end The end of the input.  If interpolating, the parsing may terminate before the end (stops at non-matching '}' token).
          * @param interpolation True if parsing for string interpolation or false if not.
-         * @return Returns the syntax tree if parsing succeeds throws parse_exception if not.
+         * @return Returns the parsed syntax tree.
          */
-        static std::shared_ptr<ast::syntax_tree> parse(lexer::lexer_string_iterator& begin, lexer::lexer_string_iterator const& end, bool interpolation = false);
+        static ast::syntax_tree parse(lexer::lexer_string_iterator& begin, lexer::lexer_string_iterator const& end, bool interpolation = false);
 
      private:
         struct expectation_info_printer
@@ -102,7 +101,7 @@ namespace puppet { namespace compiler {
         }
 
         template <typename Lexer, typename Input, typename Iterator>
-        static std::shared_ptr<ast::syntax_tree> parse(Lexer& lexer, std::string const& path, Input& input, Iterator& begin, Iterator const& end, bool interpolation)
+        static ast::syntax_tree parse(Lexer& lexer, Input& input, Iterator& begin, Iterator const& end, bool interpolation)
         {
             using namespace std;
             using namespace puppet::lexer;
@@ -115,8 +114,8 @@ namespace puppet { namespace compiler {
                 auto token_end = lexer.end();
 
                 // Parse the input into a syntax tree
-                auto tree = make_shared<ast::syntax_tree>();
-                if (qi::parse(token_begin, token_end, grammar<Lexer>(lexer, path, interpolation), *tree) &&
+                ast::syntax_tree tree;
+                if (qi::parse(token_begin, token_end, grammar<Lexer>(lexer, interpolation), tree) &&
                     (token_begin == token_end || token_begin->id() == boost::lexer::npos || interpolation)) {
                     return tree;
                 }

--- a/lib/include/puppet/runtime/catalog.hpp
+++ b/lib/include/puppet/runtime/catalog.hpp
@@ -24,13 +24,12 @@ namespace puppet { namespace runtime {
         /**
          * Creates a resource with the given type and title.
          * @param catalog The catalog that contains the resource.
-         * @param type The type of the resource (e.g. File).
-         * @param title The title of the resource (e.g. '/tmp/foo').
-         * @param file The file defining the resource.
+         * @param type The resource type (e.g. File['/tmp/foo']).
+         * @param path The path of the file defining the resource.
          * @param line The line defining the resource.
          * @param exported True if the resource is exported or false if not.
          */
-        resource(runtime::catalog& catalog, std::string type, std::string title, std::string file, size_t line, bool exported = false);
+        resource(runtime::catalog& catalog, types::resource type, std::shared_ptr<std::string> path, size_t line, bool exported = false);
 
         /**
          * Gets the catalog that contains the resource.
@@ -39,22 +38,16 @@ namespace puppet { namespace runtime {
         runtime::catalog const& catalog() const;
 
         /**
-         * Gets the type of the resource.
-         * @return Returns the type of the resource.
+         * Gets the resource type of the resource.
+         * @return Returns the resource type of the resource.
          */
-        std::string const& type() const;
+        types::resource const& type() const;
 
         /**
-         * Gets the title of the resource.
-         * @return Returns the title of the resource.
+         * Gets the path of the file where the resource was defined.
+         * @return Returns the path of the file where the resource was defined.
          */
-        std::string const& title() const;
-
-        /**
-         * Gets the file where the resource was defined.
-         * @return Returns the file where the resource was defined.
-         */
-        std::string const& file() const;
+        std::string const& path() const;
 
         /**
          * Gets the line where the resource was defined.
@@ -103,21 +96,14 @@ namespace puppet { namespace runtime {
          */
         bool remove_parameter(std::string const& name);
 
-        /**
-         * Creates a reference to this resource.
-         * @return Returns a reference to this resource.
-         */
-        types::resource create_reference() const;
-
      private:
         void store_parameter(std::string const& name, lexer::position const& name_position, values::value value, bool override);
         bool handle_metaparameter(std::string const& name, lexer::position const& name_position, values::value& value, lexer::position const& value_position);
         void create_alias(values::value const& value, lexer::position const& position);
 
         runtime::catalog& _catalog;
-        std::string _type;
-        std::string _title;
-        std::string _file;
+        types::resource _type;
+        std::shared_ptr<std::string> _path;
         size_t _line;
         std::unordered_set<std::string> _tags;
         std::unordered_map<std::string, values::value> _parameters;
@@ -130,103 +116,38 @@ namespace puppet { namespace runtime {
     struct catalog
     {
         /**
-         * Used for resource map equality.
-         */
-        struct type_equal_to : std::binary_function<std::string, std::string, bool>
-        {
-            /**
-             * Compares two strings for case-insensitive equality.
-             * @param left The left string to compare.
-             * @param right The right string to compare.
-             * @return Returns true if both strings are case-insensitively equal or false if not.
-             */
-            bool operator()(std::string const& left, std::string const& right) const
-            {
-                return boost::algorithm::iequals(left, right);
-            }
-        };
-
-        /**
-         * Used for resource map hashing.
-         */
-        struct type_hasher : std::unary_function<std::string, std::size_t>
-        {
-            /**
-             * Hashes the given type string.
-             * @param type The type string to hash.
-             * @return Returns the hash value.
-             */
-            std::size_t operator()(std::string const& type) const
-            {
-                std::size_t seed = 0;
-
-                for (char c : type)
-                {
-                    boost::hash_combine(seed, std::toupper(c));
-                }
-                return seed;
-            }
-        };
-
-        /**
-         * The type for resource map.
-         */
-        typedef std::unordered_map<std::string, std::unordered_map<std::string, resource>, type_hasher, type_equal_to> resource_map;
-        /**
-         * The type for resource alias map.
-         */
-        typedef std::unordered_map<std::string, std::unordered_map<std::string, resource*>, type_hasher, type_equal_to> resource_alias_map;
-
-        /**
          * Constructs a catalog.
          */
         catalog();
 
         /**
-         * Gets the resources currently in the catalog.
-         * @return Returns the resources currently in the catalog.
-         */
-        resource_map const& resources() const;
-
-        /**
          * Finds a resource in the catalog.
-         * @param type The type of the resource.
-         * @param title The title of the resource.
+         * @param resource The resource type to find.
          * @return Returns the resource if found or nullptr if the resource is not in the catalog.
          */
-        resource const* find_resource(std::string const& type, std::string const& title) const;
-
-        /**
-         * Finds a resource in the catalog.
-         * @param type The type of the resource.
-         * @param title The title of the resource.
-         * @return Returns the resource if found or nullptr if the resource is not in the catalog.
-         */
-        resource* find_resource(std::string const& type, std::string const& title);
+        runtime::resource* find_resource(types::resource const& resource);
 
         /**
          * Aliases a resource.
-         * @param type The type of the resource to alias.
-         * @param title The title of the resource being aliased.
+         * @param resource The reource to alias.
          * @param alias The new alias name.
          * @return Returns true if the resource was aliased or false if a resource with that name or alias already exists.
          */
-        bool alias_resource(std::string const& type, std::string const& title, std::string const& alias);
+        bool alias_resource(types::resource const& resource, std::string const& alias);
 
         /**
          * Adds a resource to the catalog.
-         * @param type The type of resource to add.
-         * @param title The title of the resource to add.
-         * @param file The file defining the resource.
+         * @param resource The qualified resource to add.
+         * @param path The path of the file defining the resource.
          * @param line The line defining the resource.
          * @param exported True if the resource is exported or false if it is not.
          * @return Returns the new resource in the catalog or nullptr if the resource already exists in the catalog.
          */
-        resource* add_resource(std::string const& type, std::string const& title, std::string const& file, size_t line, bool exported = false);
+        runtime::resource* add_resource(types::resource resource, std::shared_ptr<std::string> path, size_t line, bool exported = false);
 
      private:
-        resource_map _resources;
-        resource_alias_map _aliases;
+        std::unordered_map<std::string, std::unordered_map<std::string, resource>> _resources;
+        std::unordered_map<std::string, std::unordered_map<std::string, resource*>> _aliases;
     };
 
 }}  // puppet::runtime

--- a/lib/include/puppet/runtime/definition_scanner.hpp
+++ b/lib/include/puppet/runtime/definition_scanner.hpp
@@ -1,0 +1,36 @@
+/**
+ * @file
+ * Declares the runtime definition scanner.
+ */
+#pragma once
+
+#include "../ast/syntax_tree.hpp"
+#include "context.hpp"
+#include <memory>
+
+namespace puppet { namespace runtime {
+
+    /**
+     * Represents the runtime definition scanner.
+     * This type is responsible for scanning a syntax tree and
+     * adding classes, defined types, and nodes to the evaluation context.
+     */
+    struct definition_scanner
+    {
+        /**
+         * Constructs a definition scanner.
+         * @param context The evaluation context.
+         */
+        explicit definition_scanner(runtime::context& context);
+
+        /**
+         * Scans the given compilation context's syntax tree for definition.
+         * @param compilation_context The compilation context.
+         */
+        void scan(std::shared_ptr<compiler::context> compilation_context);
+
+     private:
+        runtime::context& _context;
+    };
+
+}}  // puppet::runtime

--- a/lib/include/puppet/runtime/executor.hpp
+++ b/lib/include/puppet/runtime/executor.hpp
@@ -49,18 +49,31 @@ namespace puppet { namespace runtime {
 
         /**
          * Executes the expression.
+         * @param scope The scope to execute under or nullptr to use an ephemeral scope.
          * @return Returns the value that was returned from the body.
          */
-        values::value execute() const;
+        values::value execute(runtime::scope* scope = nullptr) const;
 
         /**
          * Executes the expression with the given positional arguments.
-         * @param arguments The positional arguments to pass to the expression.
+         * @param arguments The positional arguments to set in the scope.
+         * @param scope The scope to execute under or nullptr to use an ephemeral scope.
          * @return Returns the value that was returned from the body.
          */
-        values::value execute(values::array& arguments) const;
+        values::value execute(values::array& arguments, runtime::scope* scope = nullptr) const;
+
+        /**
+         * Executes the expression with the given keyword arguments.
+         * @param arguments The keyword arguments to set in the scope.
+         * @param scope The scope to execute under or nullptr to use an ephemeral scope.
+         * @return Returns the value that was returned from the body.
+         */
+        values::value execute(values::hash& arguments, runtime::scope* scope = nullptr) const;
 
      private:
+        void validate_parameter(ast::parameter const& parameter, values::value const& value) const;
+        values::value evaluate_body() const;
+
         expression_evaluator& _evaluator;
         lexer::position const& _position;
         boost::optional<std::vector<ast::parameter>> const& _parameters;

--- a/lib/include/puppet/runtime/functions/include.hpp
+++ b/lib/include/puppet/runtime/functions/include.hpp
@@ -1,0 +1,24 @@
+/**
+ * @file
+ * Declares the include function.
+ */
+#pragma once
+
+#include "../call_context.hpp"
+
+namespace puppet { namespace runtime { namespace functions {
+
+    /**
+     * Implements the include function.
+     */
+    struct include
+    {
+        /**
+         * Called to invoke the function.
+         * @param context The function call context.
+         * @return Returns the resulting value.
+         */
+        values::value operator()(call_context& context) const;
+    };
+
+}}}  // puppet::runtime::functions

--- a/lib/include/puppet/runtime/scope.hpp
+++ b/lib/include/puppet/runtime/scope.hpp
@@ -8,12 +8,48 @@
 #include <unordered_map>
 #include <string>
 #include <memory>
-#include <tuple>
 #include <cstdint>
 #include <regex>
 #include <deque>
 
 namespace puppet { namespace runtime {
+
+    /**
+     * Represents an assigned variable.
+     */
+    struct assigned_variable
+    {
+        /**
+         * Constructs an assigned variable with the given value and location.
+         * @param value The value of the variable.
+         * @param path The path of the file where the variable was assigned.
+         * @param line The line where the variable was assigned.
+         */
+        assigned_variable(values::value value, std::shared_ptr<std::string> path, size_t line);
+
+        /**
+         * Gets the value of the variable.
+         * @return Returns the value of the variable.
+         */
+        values::value const& value() const;
+
+        /**
+         * Gets the path of the file where the variable was assigned.
+         * @return Returns the path of the file where the variable was assigned.
+         */
+        std::string const& path() const;
+
+        /**
+         * Gets the line where the variable was assigned.
+         * @return Returns the line where the variable was assigned.
+         */
+        size_t line() const;
+
+     private:
+        values::value _value;
+        std::shared_ptr<std::string> _path;
+        size_t _line;
+    };
 
     /**
      * Represents a runtime scope.
@@ -23,13 +59,14 @@ namespace puppet { namespace runtime {
         /**
          * Constructs a scope.
          * @param name The name of the scope (e.g. foo).
-         * @param display_name The display name of the scope (e.g. Class[Foo]).
+         * @param display_name The display name of the scope (e.g. Class[foo]).
          * @param parent The parent scope.
          */
         explicit scope(std::string name, std::string display_name, scope* parent = nullptr);
 
         /**
          * Constructs an ephemeral scope.
+         * @param parent The parent scope.
          */
         explicit scope(scope* parent);
 
@@ -63,25 +100,19 @@ namespace puppet { namespace runtime {
         /**
          * Sets a variable in the scope.
          * @param name The name of the variable.
-         * @param val The value of the variable.
+         * @param value The value of the variable.
+         * @param path The path of the file where the variable is being assigned or nullptr if unknown.
          * @param line The line number where the variable is being assigned or 0 if unknown.
-         * @return Returns a pointer to the value that was set or nullptr if the value already exists in this scope.
+         * @return Returns a pointer to the assigned variable or nullptr if the variable already exists in the scope.
          */
-        values::value const* set(std::string name, values::value val, size_t line = 0);
+        assigned_variable const* set(std::string name, values::value value, std::shared_ptr<std::string> path = nullptr, size_t line = 0);
 
         /**
          * Gets a variable in the scope.
          * @param name The name of the variable to get.
-         * @return Returns the value of the variable or nullptr if not found.
+         * @return Returns the assigned variable or nullptr if the variable does not exist in the scope.
          */
-        values::value const* get(std::string const& name) const;
-
-        /**
-         * Gets the line where the variable was assigned.
-         * @param name The variable name.
-         * @return Returns the line where the variable was assigned or 0 if unknown.
-         */
-        size_t where(std::string const& name);
+        assigned_variable const* get(std::string const& name) const;
 
         /**
          * Gets the parent scope.
@@ -117,7 +148,7 @@ namespace puppet { namespace runtime {
         std::string _name;
         std::string _display_name;
         scope* _parent;
-        std::unordered_map<std::string, std::tuple<values::value, size_t>> _variables;
+        std::unordered_map<std::string, assigned_variable> _variables;
         std::deque<std::vector<values::value>> _matches;
     };
 

--- a/lib/include/puppet/runtime/types/class.hpp
+++ b/lib/include/puppet/runtime/types/class.hpp
@@ -26,6 +26,9 @@ namespace puppet { namespace runtime { namespace types {
         explicit basic_class(std::string title = {}) :
             _title(rvalue_cast(title))
         {
+            if (boost::starts_with(_title, "::")) {
+                _title = _title.substr(2);
+            }
             boost::to_lower(_title);
         }
 

--- a/lib/src/ast/class_definition_expression.cc
+++ b/lib/src/ast/class_definition_expression.cc
@@ -54,18 +54,17 @@ namespace puppet { namespace ast {
 
         os << "class " << expr.name();
         if (expr.parameters()) {
-            os << " (";
+            os << "(";
             pretty_print(os, expr.parameters(), ", ");
             os << ")";
         }
         if (expr.parent()) {
             os << " inherits " << *expr.parent();
         }
-        os << " {";
+        os << " { ";
         pretty_print(os, expr.body(), "; ");
         os << " }";
         return os;
     }
 
 }}  // namespace puppet::ast
-

--- a/lib/src/ast/expression.cc
+++ b/lib/src/ast/expression.cc
@@ -259,11 +259,10 @@ namespace puppet { namespace ast {
 
     ostream& operator<<(ostream& os, expression const& expr)
     {
-        os << "(" << expr.primary();
+        os << expr.primary();
         for (auto const& binary : expr.binary()) {
             os << binary;
         }
-        os << ")";
         return os;
     }
 

--- a/lib/src/ast/name.cc
+++ b/lib/src/ast/name.cc
@@ -1,10 +1,17 @@
 #include <puppet/ast/name.hpp>
+#include <puppet/cast.hpp>
 
 using namespace std;
 
 namespace puppet { namespace ast {
 
     name::name()
+    {
+    }
+
+    name::name(lexer::position position, string value) :
+        _position(rvalue_cast(position)),
+        _value(rvalue_cast(value))
     {
     }
 
@@ -16,6 +23,11 @@ namespace puppet { namespace ast {
     lexer::position const& name::position() const
     {
         return _position;
+    }
+
+    bool operator==(name const& left, name const& right)
+    {
+        return left.value() == right.value();
     }
 
     ostream& operator<<(ostream& os, name const& name)

--- a/lib/src/ast/resource_expression.cc
+++ b/lib/src/ast/resource_expression.cc
@@ -100,9 +100,8 @@ namespace puppet { namespace ast {
         if (body.title().blank()) {
             return os;
         }
-        os << body.title() << ": { ";
+        os << body.title() << ": ";
         pretty_print(os, body.attributes(), ", ");
-        os << " }";
         return os;
     }
 

--- a/lib/src/ast/syntax_tree.cc
+++ b/lib/src/ast/syntax_tree.cc
@@ -8,16 +8,10 @@ using boost::optional;
 
 namespace puppet { namespace ast {
 
-    syntax_tree::syntax_tree(std::string path, optional<vector<expression>> body, lexer::position end) :
-        _path(rvalue_cast(path)),
+    syntax_tree::syntax_tree(optional<vector<expression>> body, lexer::position end) :
         _body(rvalue_cast(body)),
         _end(rvalue_cast(end))
     {
-    }
-
-    std::string const& syntax_tree::path() const
-    {
-        return _path;
     }
 
     optional<vector<expression>> const& syntax_tree::body() const

--- a/lib/src/compiler/context.cc
+++ b/lib/src/compiler/context.cc
@@ -1,0 +1,68 @@
+#include <puppet/compiler/context.hpp>
+#include <puppet/compiler/parser.hpp>
+#include <puppet/cast.hpp>
+
+using namespace std;
+using namespace puppet::lexer;
+using namespace puppet::logging;
+
+namespace puppet { namespace compiler {
+
+    context::context(logging::logger& logger, shared_ptr<string> path, compiler::node& node) :
+        _logger(logger),
+        _path(rvalue_cast(path)),
+        _node(node)
+    {
+        if (!_path) {
+            throw runtime_error("expected path");
+        }
+        _stream.open(*_path);
+        if (!_stream) {
+            throw compilation_exception("file does not exist or cannot be read.", *_path);
+        }
+
+        // Parse the file into a syntax tree
+        try {
+            _tree = parser::parse(*_path, _stream);
+        } catch (parse_exception const& ex) {
+            throw create_exception(ex.position(), ex.what());
+        }
+    }
+
+    logging::logger& context::logger()
+    {
+        return _logger;
+    }
+
+    shared_ptr<string> const& context::path() const
+    {
+        return _path;
+    }
+
+    ast::syntax_tree const& context::tree() const
+    {
+        return _tree;
+    }
+
+    compiler::node& context::node()
+    {
+        return _node;
+    }
+
+    void context::log(logging::level level, lexer::position const& position, std::string const& message)
+    {
+        string text;
+        size_t column;
+        tie(text, column) = get_text_and_column(_stream, position.offset());
+        _logger.log(level, position.line(), column, text, *_path, "node '%1%': %2%", _node.name(), message);
+    }
+
+    compilation_exception context::create_exception(lexer::position const& position, string const& message)
+    {
+        string text;
+        size_t column;
+        tie(text, column) = get_text_and_column(_stream, position.offset());
+        return compilation_exception(message, *_path, position.line(), column, rvalue_cast(text));
+    }
+
+}}  // namespace puppet::compiler

--- a/lib/src/compiler/parser.cc
+++ b/lib/src/compiler/parser.cc
@@ -18,27 +18,27 @@ namespace puppet { namespace compiler {
         return _position;
     }
 
-    shared_ptr<ast::syntax_tree> parser::parse(string const& path, ifstream& input, bool interpolation)
+    ast::syntax_tree parser::parse(string const& path, ifstream& input, bool interpolation)
     {
         file_static_lexer lexer;
         auto begin = lex_begin(input);
         auto end = lex_end(input);
-        return parse(lexer, path, input, begin, end, interpolation);
+        return parse(lexer, input, begin, end, interpolation);
     }
 
-    shared_ptr<ast::syntax_tree> parser::parse(string const& input, bool interpolation)
+    ast::syntax_tree parser::parse(string const& input, bool interpolation)
     {
         string_static_lexer lexer;
         auto begin = lex_begin(input);
         auto end = lex_end(input);
-        return parse(lexer, "<string>", input, begin, end, interpolation);
+        return parse(lexer, input, begin, end, interpolation);
     }
 
-    shared_ptr<ast::syntax_tree> parser::parse(lexer_string_iterator& begin, lexer_string_iterator const& end, bool interpolation)
+    ast::syntax_tree parser::parse(lexer_string_iterator& begin, lexer_string_iterator const& end, bool interpolation)
     {
         string_static_lexer lexer;
         auto range = boost::make_iterator_range(begin, end);
-        return parse(lexer, "<string>", range, begin, end, interpolation);
+        return parse(lexer, range, begin, end, interpolation);
     }
 
     parser::expectation_info_printer::expectation_info_printer(ostream& os) :

--- a/lib/src/runtime/definition_scanner.cc
+++ b/lib/src/runtime/definition_scanner.cc
@@ -1,0 +1,493 @@
+#include <puppet/runtime/definition_scanner.hpp>
+#include <puppet/runtime/expression_evaluator.hpp>
+#include <puppet/ast/expression_def.hpp>
+#include <puppet/cast.hpp>
+#include <boost/algorithm/string.hpp>
+
+using namespace std;
+
+namespace puppet { namespace runtime {
+
+    /**
+     * This utility type is responsible for scanning the AST for class, type, and node definitions.
+     * Because classes can be declared before they are defined, scanning needs to take place
+     * before AST evaluation.
+     */
+    struct scanning_visitor : boost::static_visitor<void>
+    {
+        scanning_visitor(shared_ptr<compiler::context> compilation_context, runtime::context& evaluation_context) :
+            _compilation_context(rvalue_cast(compilation_context)),
+            _evaluation_context(evaluation_context)
+        {
+            // Push a "top level" scope
+            _scopes.push_back("::");
+        }
+
+        result_type operator()(ast::basic_expression const& expr)
+        {
+            // Basic expressions have no class scope
+            class_scope scope(_scopes);
+
+            boost::apply_visitor(*this, expr);
+        }
+
+        result_type operator()(ast::catalog_expression const& expr)
+        {
+            boost::apply_visitor(*this, expr);
+        }
+
+        result_type operator()(ast::control_flow_expression const& expr)
+        {
+            // Control flow expressions have no class scope
+            class_scope scope(_scopes);
+
+            boost::apply_visitor(*this, expr);
+        }
+
+        result_type operator()(ast::unary_expression const& expr)
+        {
+            boost::apply_visitor(*this, expr.operand());
+        }
+
+        result_type operator()(ast::postfix_expression const& expr)
+        {
+            boost::apply_visitor(*this, expr.primary());
+
+            for (auto const& subexpression : expr.subexpressions()) {
+                boost::apply_visitor(*this, subexpression);
+            }
+        }
+
+        result_type operator()(ast::expression const& expr)
+        {
+            boost::apply_visitor(*this, expr.primary());
+
+            for (auto const& binary : expr.binary()) {
+                boost::apply_visitor(*this, binary.operand());
+            }
+        }
+
+        result_type operator()(ast::case_expression const& expr)
+        {
+            operator()(expr.expression());
+
+            for (auto const& proposition : expr.propositions()) {
+                if (proposition.lambda()) {
+                    operator()(*proposition.lambda());
+                }
+                for (auto const& option : proposition.options()) {
+                    operator()(option);
+                }
+                if (proposition.body()) {
+                    for (auto const& expression : *proposition.body()) {
+                        operator()(expression);
+                    }
+                }
+            }
+        }
+
+        result_type operator()(ast::if_expression const& expr)
+        {
+            operator()(expr.conditional());
+            if (expr.body()) {
+                for (auto const& expression : *expr.body()) {
+                    operator()(expression);
+                }
+            }
+
+            if (expr.elsifs()) {
+                for (auto const& elsif : *expr.elsifs()) {
+                    operator()(elsif.conditional());
+                    if (elsif.body()) {
+                        for (auto const& expression : *elsif.body()) {
+                            operator()(expression);
+                        }
+                    }
+                }
+            }
+
+            if (expr.else_() && expr.else_()->body()) {
+                for (auto const& expression : *expr.else_()->body()) {
+                    operator()(expression);
+                }
+            }
+        }
+
+        result_type operator()(ast::unless_expression const& expr)
+        {
+            operator()(expr.conditional());
+            if (expr.body()) {
+                for (auto const& expression : *expr.body()) {
+                    operator()(expression);
+                }
+            }
+
+            if (expr.else_() && expr.else_()->body()) {
+                for (auto const& expression : *expr.else_()->body()) {
+                    operator()(expression);
+                }
+            }
+        }
+
+        result_type operator()(ast::function_call_expression const& expr)
+        {
+            if (expr.arguments()) {
+                for (auto const& argument : *expr.arguments()) {
+                    operator()(argument);
+                }
+            }
+            if (expr.lambda()) {
+                operator()(*expr.lambda());
+            }
+        }
+
+        result_type operator()(ast::selector_expression const& expr)
+        {
+            for (auto const& case_ : expr.cases()) {
+                operator()(case_.selector());
+                operator()(case_.result());
+            }
+        }
+
+        result_type operator()(ast::access_expression const& expr)
+        {
+            for (auto const& argument : expr.arguments()) {
+                operator()(argument);
+            }
+        }
+
+        result_type operator()(ast::method_call_expression const& expr)
+        {
+            if (expr.arguments()) {
+                for (auto const& argument : *expr.arguments()) {
+                    operator()(argument);
+                }
+            }
+            if (expr.lambda()) {
+                operator()(*expr.lambda());
+            }
+        }
+
+        result_type operator()(ast::lambda const& lambda)
+        {
+            if (lambda.parameters()) {
+                for (auto const& parameter : *lambda.parameters()) {
+                    if (parameter.type()) {
+                        boost::apply_visitor(*this, *parameter.type());
+                    }
+                    if (parameter.default_value()) {
+                        operator()(*parameter.default_value());
+                    }
+                }
+            }
+
+            if (lambda.body()) {
+                for (auto const& expression : *lambda.body()) {
+                    operator()(expression);
+                }
+            }
+        }
+
+        result_type operator()(boost::blank const&)
+        {
+            // No subexpressions to scan
+        }
+
+        result_type operator()(ast::undef const&)
+        {
+            // No subexpressions to scan
+        }
+
+        result_type operator()(ast::defaulted const&)
+        {
+            // No subexpressions to scan
+        }
+
+        result_type operator()(ast::boolean const&)
+        {
+            // No subexpressions to scan
+        }
+
+        result_type operator()(ast::number const&)
+        {
+            // No subexpressions to scan
+        }
+
+        result_type operator()(ast::regex const&)
+        {
+            // No subexpressions to scan
+        }
+
+        result_type operator()(ast::variable const&)
+        {
+            // No subexpressions to scan
+        }
+
+        result_type operator()(ast::name const&)
+        {
+            // No subexpressions to scan
+        }
+
+        result_type operator()(ast::bare_word const&)
+        {
+            // No subexpressions to scan
+        }
+
+        result_type operator()(ast::type const&)
+        {
+            // No subexpressions to scan
+        }
+
+        result_type operator()(ast::string const&)
+        {
+            // TODO: implement an interpolation scanner?
+        }
+
+        result_type operator()(ast::array const& array)
+        {
+            if (array.elements()) {
+                for (auto const& element : *array.elements()) {
+                    operator()(element);
+                }
+            }
+        }
+
+        result_type operator()(ast::hash const& hash)
+        {
+            if (hash.elements()) {
+                for (auto const& pair : *hash.elements()) {
+                    operator()(pair.first);
+                    operator()(pair.second);
+                }
+            }
+        }
+
+        result_type operator()(ast::resource_expression const& expr)
+        {
+            // Resource expressions have no class scope
+            class_scope scope(_scopes);
+
+            for (auto const& body : expr.bodies()) {
+                operator()(body.title());
+                if (body.attributes()) {
+                    for (auto const& attribute : *body.attributes()) {
+                        operator()(attribute.value());
+                    }
+                }
+            }
+        }
+
+        result_type operator()(ast::resource_override_expression const& expr)
+        {
+            // Resource expressions have no class scope
+            class_scope scope(_scopes);
+
+            boost::apply_visitor(*this, expr.reference());
+
+            if (expr.attributes()) {
+                for (auto const& attribute : *expr.attributes()) {
+                    operator()(attribute.value());
+                }
+            }
+        }
+
+        result_type operator()(ast::resource_defaults_expression const& expr)
+        {
+            // Resource expressions have no class scope
+            class_scope scope(_scopes);
+
+            if (expr.attributes()) {
+                for (auto const& attribute : *expr.attributes()) {
+                    operator()(attribute.value());
+                }
+            }
+        }
+
+        result_type operator()(ast::class_definition_expression const& expr)
+        {
+            // Ensure the name is valid
+            if (boost::starts_with(expr.name().value(), "::")) {
+                throw evaluation_exception(expr.name().position(), (boost::format("'%1%' is not a valid class name.") % expr.name()).str());
+            }
+
+            if (!can_define()) {
+                throw evaluation_exception(expr.position(), "classes can only be defined at top-level scope or inside another class.");
+            }
+
+            // Define the class in the context
+            types::klass klass(qualify(expr.name().value()));
+            auto previous = _evaluation_context.define_class(klass, _compilation_context, expr);
+            if (previous) {
+                throw evaluation_exception(expr.parent()->position(),
+                    (boost::format("class '%1%' cannot inherit from '%2%' because the class already inherits from '%3%' at %4%:%5%") %
+                     klass.title() %
+                     expr.parent()->value() %
+                     previous->parent()->title() %
+                     previous->path() %
+                     previous->line()
+                    ).str());
+            }
+
+            // Scan the parameters
+            if (expr.parameters()) {
+                // Parameters have no class scope
+                class_scope scope(_scopes, {});
+
+                for (auto const& parameter : *expr.parameters()) {
+                    if (parameter.type()) {
+                        boost::apply_visitor(*this, *parameter.type());
+                    }
+                    if (parameter.default_value()) {
+                        operator()(*parameter.default_value());
+                    }
+                }
+            }
+
+            // Scan the body
+            if (expr.body()) {
+                // Set the class scope
+                class_scope scope(_scopes, expr.name().value());
+
+                for (auto const &expression : *expr.body()) {
+                    operator()(expression);
+                }
+            }
+        }
+
+        result_type operator()(ast::defined_type_expression const& expr)
+        {
+            if (!can_define()) {
+                throw evaluation_exception(expr.position(), "defined types can only be defined at top-level scope or inside a class.");
+            }
+
+            // TODO: add the defined type
+
+            // Defined types have no class scope
+            class_scope scope(_scopes, {});
+
+            // Scan the parameters
+            if (expr.parameters()) {
+                for (auto const& parameter : *expr.parameters()) {
+                    if (parameter.type()) {
+                        boost::apply_visitor(*this, *parameter.type());
+                    }
+                    if (parameter.default_value()) {
+                        operator()(*parameter.default_value());
+                    }
+                }
+            }
+
+            // Scan the body
+            if (expr.body()) {
+                for (auto const& expression : *expr.body()) {
+                    operator()(expression);
+                }
+            }
+        }
+
+        result_type operator()(ast::node_definition_expression const& expr)
+        {
+            if (!can_define()) {
+                throw evaluation_exception(expr.position(), "node definitions can only be defined at top-level scope or inside a class.");
+            }
+
+            // TODO: add the node definition
+
+            // Node definitions have no class scope
+            class_scope scope(_scopes, {});
+
+            // Scan the body
+            if (expr.body()) {
+                for (auto const &expression : *expr.body()) {
+                    operator()(expression);
+                }
+            }
+        }
+
+        result_type operator()(ast::collection_expression const& expr)
+        {
+            // Collection expressions have no class scope
+            class_scope scope(_scopes, {});
+
+            // Scan the first query's value
+            if (expr.first()) {
+                operator()(expr.first()->value());
+            }
+
+            // Scan all the remaining query expression values
+            for (auto const& binary : expr.remainder()) {
+                operator()(binary.operand().value());
+            }
+        }
+
+     private:
+        struct class_scope
+        {
+            explicit class_scope(deque<string>& scopes, string name = {}) :
+                _scopes(scopes)
+            {
+                scopes.push_back(std::move(name));
+            }
+
+            ~class_scope()
+            {
+                _scopes.pop_back();
+            }
+
+         private:
+            deque<string>& _scopes;
+        };
+
+        bool can_define() const
+        {
+            return !_scopes.back().empty();
+        }
+
+        string qualify(std::string const& name)
+        {
+            if (_scopes.size() < 2) {
+                return name;
+            }
+
+            string qualified;
+            for (auto it = _scopes.begin() + 1; it != _scopes.end(); ++it) {
+                if (!qualified.empty()) {
+                    qualified += "::";
+                }
+                qualified += *it;
+            }
+            if (!qualified.empty()) {
+                qualified += "::";
+            }
+            qualified += name;
+            return qualified;
+        }
+
+        shared_ptr<compiler::context> _compilation_context;
+        runtime::context& _evaluation_context;
+        deque<string> _scopes;
+    };
+
+    definition_scanner::definition_scanner(runtime::context& context) :
+        _context(context)
+    {
+    }
+
+    void definition_scanner::scan(shared_ptr<compiler::context> compilation_context)
+    {
+        if (!compilation_context) {
+            return;
+        }
+
+        auto& tree = compilation_context->tree();
+        if (!tree.body()) {
+            return;
+        }
+
+        scanning_visitor visitor(rvalue_cast(compilation_context), _context);
+        for (auto const& expression : *tree.body()) {
+            visitor(expression);
+        }
+    }
+
+}}  // namespace puppet::runtime

--- a/lib/src/runtime/dispatcher.cc
+++ b/lib/src/runtime/dispatcher.cc
@@ -3,6 +3,7 @@
 #include <puppet/runtime/functions/each.hpp>
 #include <puppet/runtime/functions/fail.hpp>
 #include <puppet/runtime/functions/filter.hpp>
+#include <puppet/runtime/functions/include.hpp>
 #include <puppet/runtime/functions/logging.hpp>
 #include <puppet/runtime/functions/split.hpp>
 #include <puppet/runtime/functions/with.hpp>
@@ -146,6 +147,7 @@ namespace puppet { namespace runtime {
             { "err",            functions::logging_function(logging::level::error) },
             { "fail",           functions::fail() },
             { "filter",         functions::filter() },
+            { "include",        functions::include() },
             { "info",           functions::logging_function(logging::level::info) },
             { "notice",         functions::logging_function(logging::level::notice) },
             { "split",          functions::split() },
@@ -156,7 +158,7 @@ namespace puppet { namespace runtime {
         // Find the function
         auto it = functions.find(_name);
         if (it == functions.end()) {
-            throw evaluation_exception(_position, (boost::format("unknown function \"%1%\".") % _name).str());
+            throw evaluation_exception(_position, (boost::format("unknown function '%1%'.") % _name).str());
         }
         _function = &it->second;
     }

--- a/lib/src/runtime/evaluators/basic.cc
+++ b/lib/src/runtime/evaluators/basic.cc
@@ -79,10 +79,10 @@ namespace puppet { namespace runtime { namespace evaluators {
                 throw evaluation_exception(var.position(), (boost::format("variable name $%1% is not a valid match variable name.") % var.name()).str());
             }
             // Look up the match
-            val = _evaluator.context().scope().get(stoi(name));
+            val = _evaluator.scope().get(stoi(name));
             match = true;
         } else {
-            val = _evaluator.context().lookup(name, &var.position());
+            val = _evaluator.lookup(name, &var.position());
         }
         return variable(name, val, match);
     }

--- a/lib/src/runtime/evaluators/control_flow.cc
+++ b/lib/src/runtime/evaluators/control_flow.cc
@@ -22,7 +22,7 @@ namespace puppet { namespace runtime { namespace evaluators {
     control_flow_expression_evaluator::result_type control_flow_expression_evaluator::operator()(ast::case_expression const& expr)
     {
         // Case expressions create a new match scope
-        match_variable_scope match_scope(_evaluator.context().scope());
+        match_variable_scope match_scope(_evaluator.scope());
 
         // Evaluate the case's expression
         value result = _evaluator.evaluate(expr.expression());
@@ -89,7 +89,7 @@ namespace puppet { namespace runtime { namespace evaluators {
     control_flow_expression_evaluator::result_type control_flow_expression_evaluator::operator()(ast::if_expression const& expr)
     {
         // If expressions create a new match scope
-        match_variable_scope match_scope(_evaluator.context().scope());
+        match_variable_scope match_scope(_evaluator.scope());
 
         if (is_truthy(_evaluator.evaluate(expr.conditional()))) {
             return execute_block(expr.body());
@@ -110,7 +110,7 @@ namespace puppet { namespace runtime { namespace evaluators {
     control_flow_expression_evaluator::result_type control_flow_expression_evaluator::operator()(ast::unless_expression const& expr)
     {
         // Unless expressions create a new match scope
-        match_variable_scope match_scope(_evaluator.context().scope());
+        match_variable_scope match_scope(_evaluator.scope());
 
         if (!is_truthy(_evaluator.evaluate(expr.conditional()))) {
             return execute_block(expr.body());

--- a/lib/src/runtime/evaluators/postfix.cc
+++ b/lib/src/runtime/evaluators/postfix.cc
@@ -34,7 +34,7 @@ namespace puppet { namespace runtime { namespace evaluators {
     postfix_expression_evaluator::result_type postfix_expression_evaluator::operator()(ast::selector_expression const& expr)
     {
         // Selector expressions create a new match scope
-        match_variable_scope match_scope(_evaluator.context().scope());
+        match_variable_scope match_scope(_evaluator.scope());
 
         boost::optional<size_t> default_index;
 

--- a/lib/src/runtime/functions/assert_type.cc
+++ b/lib/src/runtime/functions/assert_type.cc
@@ -12,7 +12,7 @@ namespace puppet { namespace runtime { namespace functions {
         // Check the argument count
         auto& arguments = context.arguments();
         if (arguments.size() != 2) {
-            throw evaluation_exception(arguments.size() > 2 ? context.position(2) : context.position(), (boost::format("expected 2 arguments to 'assert_type' function but %1% were given.") % arguments.size()).str());
+            throw evaluation_exception(arguments.size() > 2 ? context.position(2) : context.position(), (boost::format("expected 2 arguments to '%1%' function but %2% were given.") % context.name() % arguments.size()).str());
         }
 
         // First argument should be a type (TODO: should accept a string that is a type name too)

--- a/lib/src/runtime/functions/each.cc
+++ b/lib/src/runtime/functions/each.cc
@@ -114,7 +114,7 @@ namespace puppet { namespace runtime { namespace functions {
         // Check the argument count
         auto& arguments = context.arguments();
         if (arguments.size() != 1) {
-            throw evaluation_exception(arguments.size() > 1 ? context.position(1) : context.position(), (boost::format("expected 1 argument to 'each' function but %1% were given.") % arguments.size()).str());
+            throw evaluation_exception(arguments.size() > 1 ? context.position(1) : context.position(), (boost::format("expected 1 argument to '%1%' function but %2% were given.") % context.name() % arguments.size()).str());
         }
 
         // Check the lambda

--- a/lib/src/runtime/functions/filter.cc
+++ b/lib/src/runtime/functions/filter.cc
@@ -139,7 +139,7 @@ namespace puppet { namespace runtime { namespace functions {
         // Check the argument count
         auto& arguments = context.arguments();
         if (arguments.size() != 1) {
-            throw evaluation_exception(arguments.size() > 1 ? context.position(1) : context.position(), (boost::format("expected 1 argument to 'filter' function but %1% were given.") % arguments.size()).str());
+            throw evaluation_exception(arguments.size() > 1 ? context.position(1) : context.position(), (boost::format("expected 1 argument to '%1%' function but %2% were given.") % context.name() % arguments.size()).str());
         }
 
         // Check the lambda

--- a/lib/src/runtime/functions/include.cc
+++ b/lib/src/runtime/functions/include.cc
@@ -1,0 +1,94 @@
+#include <puppet/runtime/functions/include.hpp>
+#include <puppet/runtime/executor.hpp>
+#include <puppet/cast.hpp>
+
+using namespace std;
+using namespace puppet::lexer;
+using namespace puppet::runtime::values;
+
+namespace puppet { namespace runtime { namespace functions {
+
+    struct include_visitor : boost::static_visitor<void>
+    {
+        include_visitor(call_context& context, size_t index) :
+            _context(context),
+            _index(index)
+        {
+        }
+
+        result_type operator()(string const& argument) const
+        {
+            declare_class(types::klass(argument));
+        }
+
+        result_type operator()(values::type const& argument) const
+        {
+            boost::apply_visitor(*this, argument);
+        }
+
+        result_type operator()(values::array const& argument) const
+        {
+            for (auto const& element : argument) {
+                boost::apply_visitor(*this, element);
+            }
+        }
+
+        result_type operator()(types::klass const& argument) const
+        {
+            declare_class(argument);
+        }
+
+        result_type operator()(types::resource const& argument) const
+        {
+            if (argument.type_name() != "Class") {
+                throw evaluation_exception(_context.position(_index), (boost::format("expected Class %1% for argument but found %2%.") % types::resource::name() % argument).str());
+            }
+            declare_class(types::klass(argument.title()));
+        }
+
+        template <typename T>
+        result_type operator()(T const& argument) const
+        {
+            throw evaluation_exception(_context.position(_index),
+                (boost::format("expected %1%, %2%, %3%, or Class %4% for argument but found %5%.") %
+                   types::string::name() %
+                   types::array::name() %
+                   types::klass::name() %
+                   types::resource::name() %
+                   get_type(argument)).str());
+        }
+
+     private:
+        void declare_class(types::klass const& klass) const
+        {
+            if (klass.title().empty()) {
+                throw evaluation_exception(_context.position(_index), "cannot include a Class with an unspecified title.");
+            }
+
+            auto& evaluator = _context.evaluator();
+            if (!evaluator.is_class_defined(klass)) {
+                throw evaluation_exception(_context.position(_index), (boost::format("cannot include class '%1%' because the class has not been defined.") % klass.title()).str());
+            }
+
+            if (!evaluator.declare_class(klass, _context.position(_index))) {
+                throw evaluation_exception(_context.position(_index), (boost::format("failed to include class '%1%'.") % klass.title()).str());
+            }
+        }
+
+        call_context& _context;
+        size_t _index;
+    };
+
+    value include::operator()(call_context& context) const
+    {
+        auto& arguments = context.arguments();
+        if (arguments.empty()) {
+            throw evaluation_exception(context.position(), (boost::format("expected at least one argument to '%1%' function.") % context.name()).str());
+        }
+        for (size_t i = 0; i < arguments.size(); ++i) {
+            boost::apply_visitor(include_visitor(context, i), arguments[i]);
+        }
+        return value();
+    }
+
+}}}  // namespace puppet::runtime::functions

--- a/lib/src/runtime/functions/logging.cc
+++ b/lib/src/runtime/functions/logging.cc
@@ -18,7 +18,8 @@ namespace puppet { namespace runtime { namespace functions {
         join(ss, context.arguments(), " ");
         string message = ss.str();
 
-        context.evaluator().context().logger().log(_level, "%1%: %2%", context.evaluator().context().scope(), message);
+        auto& evaluator = context.evaluator();
+        evaluator.logger().log(_level, "%1%: %2%", evaluator.scope(), message);
         return message;
     }
 

--- a/lib/src/runtime/functions/split.cc
+++ b/lib/src/runtime/functions/split.cc
@@ -94,7 +94,7 @@ namespace puppet { namespace runtime { namespace functions {
     {
         auto& arguments = context.arguments();
         if (arguments.size() != 2) {
-            throw evaluation_exception(arguments.size() > 2 ? context.position(2) : context.position(), (boost::format("expected 2 arguments to 'split' function but %1% were given.") % arguments.size()).str());
+            throw evaluation_exception(arguments.size() > 2 ? context.position(2) : context.position(), (boost::format("expected 2 arguments to '%1%' function but %2% were given.") % context.name() % arguments.size()).str());
         }
         return boost::apply_visitor(split_visitor(context), dereference(arguments[0]), dereference(arguments[1]));
     }

--- a/lib/src/runtime/operators/in.cc
+++ b/lib/src/runtime/operators/in.cc
@@ -23,7 +23,7 @@ namespace puppet { namespace runtime { namespace operators {
         {
             smatch matches;
             bool result = left.pattern().empty() || regex_search(right, matches, left.value());
-            _context.evaluator().context().scope().set(matches);
+            _context.evaluator().scope().set(matches);
             return result;
         }
 

--- a/lib/src/runtime/operators/match.cc
+++ b/lib/src/runtime/operators/match.cc
@@ -19,7 +19,7 @@ namespace puppet { namespace runtime { namespace operators {
         {
             smatch matches;
             bool result = right.empty() || regex_search(left, matches, std::regex(right));
-            _context.evaluator().context().scope().set(matches);
+            _context.evaluator().scope().set(matches);
             return result;
         }
 
@@ -27,7 +27,7 @@ namespace puppet { namespace runtime { namespace operators {
         {
             smatch matches;
             bool result = right.pattern().empty() || regex_search(left, matches, right.value());
-            _context.evaluator().context().scope().set(matches);
+            _context.evaluator().scope().set(matches);
             return result;
         }
 


### PR DESCRIPTION
This commit refactors the previous implementation of class definitions
to allow the AST to be scanned for definitions (node, class, defined
type) before AST evaluation.  This is because Puppet allows referencing
the definitions before they are defined (e.g. `include foo` may come
before `class foo {}`).

This also implements two ways for declaring classes:

* The include function.
* Class resource expressions with or without passing parameters.

Other various refactorings will allow this implementation to easily
support defined type expressions when the time comes.