### PR TITLE
Implement node definition expression evaluation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Expression evaluator status:
 * [ ] resource override expressions (NYI: scope check and `+>`)
 * [x] class definition expressions
 * [x] defined type expressions
-* [ ] node definition expressions
+* [x] node definition expressions
 * [ ] collection expressions
 * [ ] loading files from modules
 * [x] access expressions
 * [x] global scope
 * [x] local scope
-* [ ] node scope
+* [x] node scope
 * [x] string interpolation
 * [ ] external data lookups (i.e. hiera)
 * [ ] EPP support

--- a/lib/include/puppet/compiler/node.hpp
+++ b/lib/include/puppet/compiler/node.hpp
@@ -8,6 +8,8 @@
 #include "../runtime/catalog.hpp"
 #include "environment.hpp"
 #include <exception>
+#include <functional>
+#include <set>
 
 namespace puppet { namespace compiler {
 
@@ -67,11 +69,11 @@ namespace puppet { namespace compiler {
          * @param name The name of the node.
          * @param environment The environment for the node.
          */
-        node(std::string name, compiler::environment& environment);
+        node(std::string const& name, compiler::environment& environment);
 
         /**
-         * Gets the name of the node.
-         * @return Returns the name of the node.
+         * Gets the display name of the node.
+         * @return Returns the display name of the node.
          */
         std::string const& name() const;
 
@@ -89,8 +91,14 @@ namespace puppet { namespace compiler {
          */
         runtime::catalog compile(logging::logger& logger, std::string const& path);
 
+        /**
+         * Calls the given callback for each name associated with the node.
+         * @param callback The callback to call for each name.
+         */
+        void each_name(std::function<bool(std::string const&)> const& callback) const;
+
      private:
-        std::string _name;
+        std::set<std::string> _names;
         compiler::environment& _environment;
     };
 

--- a/lib/include/puppet/runtime/context.hpp
+++ b/lib/include/puppet/runtime/context.hpp
@@ -130,6 +130,42 @@ namespace puppet { namespace runtime {
     };
 
     /**
+     * Represents a node definition.
+     */
+    struct node_definition
+    {
+        /**
+         * Constructs a node definition.
+         * @param context The compilation context for the node definition.
+         * @param expression The node definition expression.
+         */
+        node_definition(std::shared_ptr<compiler::context> context, ast::node_definition_expression const& expression);
+
+        /**
+         * Gets the path of the file containing the node definition.
+         * @return Returns the path of the file containing the node definition.
+         */
+        std::string const& path() const;
+
+        /**
+         * Gets the line number of the node definition.
+         * @return Returns the line number of the node definition.
+         */
+        size_t line() const;
+
+        /**
+         * Evaluates the node definition.
+         * @param context The evaluation context.
+         * @return Returns true if the evaluation succeeded or false if it did not.
+         */
+        bool evaluate(runtime::context& context);
+
+     private:
+        std::shared_ptr<compiler::context> _context;
+        ast::node_definition_expression const& _expression;
+    };
+
+    /**
      * Represents the evaluation context.
      */
     struct context
@@ -191,9 +227,8 @@ namespace puppet { namespace runtime {
          * @param klass The class to define.
          * @param context The compilation context.
          * @param expression The class definition expression.
-         * @return Returns nullptr if the class was successfully defined or existing class definition that cannot be merged with the given definition.
          */
-        class_definition const* define_class(types::klass klass, std::shared_ptr<compiler::context> context, ast::class_definition_expression const& expression);
+        void define_class(types::klass klass, std::shared_ptr<compiler::context> context, ast::class_definition_expression const& expression);
 
         /**
          * Declares a class.
@@ -225,9 +260,8 @@ namespace puppet { namespace runtime {
          * @param type The type to define.
          * @param context The compilation context.
          * @param expression The defined type expression.
-         * @return Returns nullptr if the type was successfully defined or a pointer to the existing defined type if already defined.
          */
-        defined_type const* define_type(std::string type, std::shared_ptr<compiler::context> context, ast::defined_type_expression const& expression);
+        void define_type(std::string type, std::shared_ptr<compiler::context> context, ast::defined_type_expression const& expression);
 
         /**
          * Determines if the given type name is a defined type.
@@ -247,6 +281,20 @@ namespace puppet { namespace runtime {
          */
         runtime::resource* declare_defined_type(std::string const& type, std::string const& title, std::shared_ptr<std::string> path, lexer::position const& position, std::unordered_map<ast::name, values::value> const* arguments = nullptr);
 
+        /**
+         * Defines a node.
+         * @param context The compilation context.
+         * @param expression The node definition expression.
+         */
+        void define_node(std::shared_ptr<compiler::context> context, ast::node_definition_expression const& expression);
+
+        /**
+         * Evaluates a node definition for the given node.
+         * @param node The node to evaluate for.
+         * @return Returns true if evaluation was successful or false if it was not.
+         */
+        bool evaluate_node(compiler::node const& node);
+
      private:
         void validate_parameters(bool klass, std::vector<ast::parameter> const& parameters);
 
@@ -255,6 +303,10 @@ namespace puppet { namespace runtime {
         std::deque<runtime::scope*> _scope_stack;
         std::unordered_map<types::klass, std::vector<class_definition>, boost::hash<types::klass>> _classes;
         std::unordered_map<std::string, defined_type> _defined_types;
+        std::vector<node_definition> _nodes;
+        std::unordered_map<std::string, size_t> _named_nodes;
+        std::vector<std::pair<values::regex, size_t>> _regex_node_definitions;
+        ssize_t _default_node_index;
     };
 
     /**

--- a/lib/src/compiler/context.cc
+++ b/lib/src/compiler/context.cc
@@ -23,7 +23,9 @@ namespace puppet { namespace compiler {
 
         // Parse the file into a syntax tree
         try {
+            logger.log(level::debug, "parsing '%1%'.", *_path);
             _tree = parser::parse(*_path, _stream);
+            logger.log(level::debug, "parsed syntax tree:\n%1%", _tree);
         } catch (parse_exception const& ex) {
             throw create_exception(ex.position(), ex.what());
         }

--- a/lib/src/runtime/definition_scanner.cc
+++ b/lib/src/runtime/definition_scanner.cc
@@ -315,18 +315,7 @@ namespace puppet { namespace runtime {
             }
 
             // Define the class in the context
-            types::klass klass(qualify(expr.name().value()));
-            auto previous = _evaluation_context.define_class(klass, _compilation_context, expr);
-            if (previous) {
-                throw evaluation_exception(expr.parent()->position(),
-                    (boost::format("class '%1%' cannot inherit from '%2%' because the class already inherits from '%3%' at %4%:%5%.") %
-                     klass.title() %
-                     expr.parent()->value() %
-                     previous->parent()->title() %
-                     previous->path() %
-                     previous->line()
-                    ).str());
-            }
+             _evaluation_context.define_class(types::klass(qualify(expr.name().value())), _compilation_context, expr);
 
             // Scan the parameters
             if (expr.parameters()) {
@@ -361,15 +350,7 @@ namespace puppet { namespace runtime {
             }
 
             // Define the type in the context
-            auto previous = _evaluation_context.define_type(qualify(expr.name().value()), _compilation_context, expr);
-            if (previous) {
-                throw evaluation_exception(expr.name().position(),
-                                           (boost::format("defined type '%1%' was previously defined at %2%:%3%.") %
-                                            previous->type() %
-                                            previous->path() %
-                                            previous->line()
-                                           ).str());
-            }
+            _evaluation_context.define_type(qualify(expr.name().value()), _compilation_context, expr);
 
             // Defined types have no class scope
             class_scope scope(_scopes, {});
@@ -400,7 +381,8 @@ namespace puppet { namespace runtime {
                 throw evaluation_exception(expr.position(), "node definitions can only be defined at top-level scope or inside a class.");
             }
 
-            // TODO: add the node definition
+            // Define the node in the context
+            _evaluation_context.define_node(_compilation_context, expr);
 
             // Node definitions have no class scope
             class_scope scope(_scopes, {});

--- a/lib/src/runtime/evaluators/basic.cc
+++ b/lib/src/runtime/evaluators/basic.cc
@@ -60,8 +60,8 @@ namespace puppet { namespace runtime { namespace evaluators {
     {
         try {
             return values::regex(regx.value());
-        } catch (std::regex_error const& ex) {
-            throw evaluation_exception(regx.position(), ex.what());
+        } catch (regex_error const& ex) {
+            throw evaluation_exception(regx.position(), (boost::format("invalid regular expression: %1%") % ex.what()).str());
         }
     }
 

--- a/lib/src/runtime/evaluators/catalog.cc
+++ b/lib/src/runtime/evaluators/catalog.cc
@@ -194,8 +194,9 @@ namespace puppet { namespace runtime { namespace evaluators {
 
     catalog_expression_evaluator::result_type catalog_expression_evaluator::operator()(ast::node_definition_expression const& expr)
     {
-        // TODO: implement
-        throw evaluation_exception(expr.position(), "node definition expressions are not yet implemented.");
+        // Node definition expressions are handled by the definition scanner
+        // Just return undef
+        return values::undef();
     }
 
     catalog_expression_evaluator::result_type catalog_expression_evaluator::operator()(ast::collection_expression const& expr)

--- a/lib/src/runtime/operators/match.cc
+++ b/lib/src/runtime/operators/match.cc
@@ -17,10 +17,14 @@ namespace puppet { namespace runtime { namespace operators {
 
         result_type operator()(string const& left, string const& right)
         {
-            smatch matches;
-            bool result = right.empty() || regex_search(left, matches, std::regex(right));
-            _context.evaluator().scope().set(matches);
-            return result;
+            try {
+                smatch matches;
+                bool result = right.empty() || regex_search(left, matches, std::regex(right));
+                _context.evaluator().scope().set(matches);
+                return result;
+            } catch (regex_error const& ex) {
+                throw evaluation_exception(_context.right_position(), (boost::format("invalid regular expression: %1%") % ex.what()).str());
+            }
         }
 
         result_type operator()(string const& left, values::regex const& right)


### PR DESCRIPTION
Implementing node definition expression evaluation.  This implements
default, named, and regex-based node definition expressions.

This also fixes the match operator where invalid regular expression
strings were not being properly handled.