### PR TITLE
Refactoring to resource expression evaluation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,11 @@ Expression evaluator status:
 * [x] function call expressions
 * [x] lambdas
 * [x] resource expressions
-* [x] `alias` metaparameter
-* [x] `audit` metaparameter (explicitly not supported)
-* [ ] `before` metaparameter
-* [ ] `loglevel` metaparameter
-* [ ] `noop` metaparameter
-* [ ] `notify` metaparameter
-* [ ] `require` metaparameter
-* [ ] `schedule` metaparameter
-* [ ] `stage` metaparameter
-* [ ] `subscribe` metaparameter
-* [ ] `tag` metaparameter
+* [x] resource metaparameters
 * [ ] virtual resource expressions
 * [ ] exported resource expressions
 * [ ] resource defaults expressions
-* [ ] resource override expressions (NYI: scope check and `+>`)
+* [ ] resource override expressions (NYI: scope checking)
 * [x] class definition expressions
 * [x] defined type expressions
 * [x] node definition expressions

--- a/lib/include/puppet/ast/case_expression.hpp
+++ b/lib/include/puppet/ast/case_expression.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "expression.hpp"
-#include "lambda.hpp"
 #include <boost/optional.hpp>
 #include <vector>
 
@@ -29,24 +28,10 @@ namespace puppet { namespace ast {
         case_proposition(std::vector<expression> options, boost::optional<std::vector<expression>> body);
 
         /**
-         * Constructs a case proposition with the given lambda option and body expressions.
-         * @param option The case proposition lambda.
-         * @param body The expressions that make up the body of the proposition.
-         */
-        case_proposition(ast::lambda option, boost::optional<std::vector<expression>> body);
-
-        /**
          * Gets the case proposition options.
          * @return Returns the case proposition options.
          */
         std::vector<expression> const& options() const;
-
-        /**
-         * Gets the optional case proposition lambda.
-         * If present, this should be respected over the option expressions.
-         * @return Returns the optional case proposition lambda.
-         */
-        boost::optional<ast::lambda> const& lambda() const;
 
         /**
          * Gets the expressions that make up the body of the proposition.
@@ -63,7 +48,6 @@ namespace puppet { namespace ast {
      private:
         lexer::position _position;
         std::vector<expression> _options;
-        boost::optional<ast::lambda> _lambda;
         boost::optional<std::vector<expression>> _body;
     };
 

--- a/lib/include/puppet/ast/resource_expression.hpp
+++ b/lib/include/puppet/ast/resource_expression.hpp
@@ -176,13 +176,13 @@ namespace puppet { namespace ast {
          * @param bodies The resource bodies being defined.
          * @param status The resource status.
          */
-        resource_expression(ast::name type, std::vector<resource_body> bodies, resource_status status = resource_status::realized);
+        resource_expression(ast::primary_expression type, std::vector<resource_body> bodies, resource_status status = resource_status::realized);
 
         /**
          * Gets the type expression of the resource being defined.
          * @return Returns the type expression of the resource being defined.
          */
-        ast::name const& type() const;
+        ast::primary_expression const& type() const;
 
         /**
          * Gets the resource bodies that are being defined.
@@ -203,7 +203,7 @@ namespace puppet { namespace ast {
         lexer::position const& position() const;
 
      private:
-        ast::name _type;
+        ast::primary_expression _type;
         std::vector<resource_body> _bodies;
         resource_status _status;
     };

--- a/lib/include/puppet/ast/resource_expression.hpp
+++ b/lib/include/puppet/ast/resource_expression.hpp
@@ -188,7 +188,7 @@ namespace puppet { namespace ast {
          * Gets the resource bodies that are being defined.
          * @return Returns the resource bodies that are being defined.
          */
-        std::vector<resource_body> bodies() const;
+        std::vector<resource_body> const& bodies() const;
 
         /**
          * Gets the status of the resource.

--- a/lib/include/puppet/compiler/grammar.hpp
+++ b/lib/include/puppet/compiler/grammar.hpp
@@ -146,7 +146,6 @@ namespace puppet { namespace compiler {
             case_expression =
                 (token_pos(token_id::keyword_case) > expression > raw_token('{') > +case_proposition > raw_token('}')) [ _val = phx::construct<ast::case_expression>(_1, _2, _3) ];
             case_proposition =
-                (lambda > raw_token(':') > raw_token('{') > statements > raw_token('}'))      [ _val = phx::construct<ast::case_proposition>(_1, _2) ] |
                 (expressions > raw_token(':') > raw_token('{') > statements > raw_token('}')) [ _val = phx::construct<ast::case_proposition>(_1, _2) ];
             if_expression =
                 (token_pos(token_id::keyword_if) > expression > raw_token('{') > statements > raw_token('}') > *elsif_expression > -else_expression) [ _val = phx::construct<ast::if_expression>(_1, _2, _3, _4, _5) ];

--- a/lib/include/puppet/compiler/grammar.hpp
+++ b/lib/include/puppet/compiler/grammar.hpp
@@ -174,8 +174,9 @@ namespace puppet { namespace compiler {
                 (raw_token(token_id::atat) > resource_type > raw_token('{') > (resource_body % raw_token(';')) > -raw_token(';') > raw_token('}')) [ _val = phx::construct<ast::resource_expression>(_1, _2, ast::resource_status::exported) ] |
                 ((resource_type >> raw_token('{')) >> (resource_body % raw_token(';')) > -raw_token(';') > raw_token('}'))                         [ _val = phx::construct<ast::resource_expression>(_1, _2) ];
             resource_type =
-                name                           [ _val = _1 ] |
-                token(token_id::keyword_class) [ _val = phx::construct<ast::name>(_1) ];
+                name                           [ _val = phx::construct<ast::basic_expression>(_1) ] |
+                token(token_id::keyword_class) [ _val = phx::construct<ast::basic_expression>(phx::construct<ast::name>(_1)) ] |
+                type_expression                [ _val = _1 ];
             resource_body =
                 ((expression >> raw_token(':')) > -(attribute_expression % raw_token(',')) > -raw_token(',')) [ _val = phx::construct<ast::resource_body>(_1, _2) ];
             attribute_expression =
@@ -519,7 +520,7 @@ namespace puppet { namespace compiler {
         // Catalog expressions
         boost::spirit::qi::rule<iterator_type, puppet::ast::catalog_expression()> catalog_expression;
         boost::spirit::qi::rule<iterator_type, puppet::ast::resource_expression()> resource_expression;
-        boost::spirit::qi::rule<iterator_type, puppet::ast::name()> resource_type;
+        boost::spirit::qi::rule<iterator_type, puppet::ast::primary_expression()> resource_type;
         boost::spirit::qi::rule<iterator_type, puppet::ast::resource_body()> resource_body;
         boost::spirit::qi::rule<iterator_type, puppet::ast::attribute_expression()> attribute_expression;
         boost::spirit::qi::rule<iterator_type, puppet::ast::attribute_operator()> attribute_operator;

--- a/lib/include/puppet/runtime/context.hpp
+++ b/lib/include/puppet/runtime/context.hpp
@@ -146,20 +146,20 @@ namespace puppet { namespace runtime {
         void set(std::smatch const& matches);
 
         /**
-         * Looks up a variable.
+         * Looks up a variable's value.
          * @param name The name of the variable to look up.
          * @param evaluator The expression evaluator to use to log warnings for scope lookup failures.  Requires a position.
          * @param position The position where the lookup is taking place or nullptr if not in source.
-         * @return Returns a pointer to the variable if found or nullptr if the variable was not found.
+         * @return Returns the variable's value or nullptr if the variable was not found.
          */
-        values::value const* lookup(std::string const& name, expression_evaluator* evaluator = nullptr, lexer::position const* position = nullptr);
+        std::shared_ptr<values::value const> lookup(std::string const& name, expression_evaluator* evaluator = nullptr, lexer::position const* position = nullptr);
 
         /**
-         * Looks up a match variable by index.
+         * Looks up a match variable value by index.
          * @param index The index of the match variable.
          * @return Returns the match variable's value or nullptr if the variable wasn't found.
          */
-        values::value const* lookup(size_t index) const;
+        std::shared_ptr<values::value const> lookup(size_t index) const;
 
         /**
          * Creates a match scope.
@@ -183,7 +183,7 @@ namespace puppet { namespace runtime {
         std::unordered_map<std::string, std::shared_ptr<runtime::scope>> _scopes;
         std::vector<std::shared_ptr<runtime::scope>> _scope_stack;
         std::shared_ptr<runtime::scope> _node_scope;
-        std::vector<std::shared_ptr<values::array>> _match_stack;
+        std::vector<std::shared_ptr<std::vector<std::shared_ptr<values::value const>>>> _match_stack;
     };
 
 }}  // namespace puppet::runtime

--- a/lib/include/puppet/runtime/evaluators/catalog.hpp
+++ b/lib/include/puppet/runtime/evaluators/catalog.hpp
@@ -38,7 +38,7 @@ namespace puppet { namespace runtime { namespace evaluators {
         result_type operator()(ast::collection_expression const& expr);
 
         result_type declare_classes(ast::resource_expression const& expr);
-        result_type declare_defined_types(ast::resource_expression const& expr);
+        result_type declare_defined_types(ast::resource_expression const& expr, std::string const& type_name);
 
         template <typename T>
         bool for_each(values::value& parameter, std::function<void(T&)> const& callback)

--- a/lib/include/puppet/runtime/evaluators/catalog.hpp
+++ b/lib/include/puppet/runtime/evaluators/catalog.hpp
@@ -6,6 +6,9 @@
 
 #include "../expression_evaluator.hpp"
 #include <boost/format.hpp>
+#include <vector>
+#include <memory>
+#include <tuple>
 
 namespace puppet { namespace runtime { namespace evaluators {
 
@@ -37,8 +40,11 @@ namespace puppet { namespace runtime { namespace evaluators {
         result_type operator()(ast::node_definition_expression const& expr);
         result_type operator()(ast::collection_expression const& expr);
 
-        result_type declare_classes(ast::resource_expression const& expr);
-        result_type declare_defined_types(ast::resource_expression const& expr, std::string const& type_name);
+        static bool is_default_expression(ast::primary_expression const& expr);
+        static ast::resource_body const* find_default_body(ast::resource_expression const& expr);
+        std::shared_ptr<runtime::attributes> evaluate_attributes(ast::resource_body const* body, std::shared_ptr<runtime::attributes const> parent = nullptr);
+        values::value evaluate_attribute(ast::attribute_expression const& attribute);
+        static lexer::position find_attribute_position(bool name_position, std::string const& name, ast::resource_body const& current, ast::resource_body const* default_body = nullptr);
 
         template <typename T>
         bool for_each(values::value& parameter, std::function<void(T&)> const& callback)

--- a/lib/include/puppet/runtime/executor.hpp
+++ b/lib/include/puppet/runtime/executor.hpp
@@ -57,21 +57,31 @@ namespace puppet { namespace runtime {
         /**
          * Executes the expression with the given positional arguments.
          * @param arguments The positional arguments to set in the scope.
+         * @param argument_position The callback to use to get the position of an argument. If nullptr, the parameter position is used.
          * @param scope The scope to execute under or nullptr to use an ephemeral scope.
          * @return Returns the value that was returned from the body.
          */
-        values::value execute(values::array& arguments, std::shared_ptr<runtime::scope> const& scope = nullptr) const;
+        values::value execute(
+            values::array& arguments,
+            std::function<boost::optional<lexer::position>(size_t)> const& argument_position = nullptr,
+            std::shared_ptr<runtime::scope> const& scope = nullptr) const;
 
         /**
-         * Executes the expression with the given keyword arguments.
-         * @param arguments The keyword arguments to set in the scope.
+         * Executes the expression with the given resource's attributes.
+         * @param resource The resource attributes to set in the scope.
+         * @param attribute_name_position The callback to use to get the location of an attribute's name.
+         * @param attribute_value_position The callback to use to get the location of an attribute's value.
          * @param scope The scope to execute under or nullptr to use an ephemeral scope.
          * @return Returns the value that was returned from the body.
          */
-        values::value execute(values::hash& arguments, std::shared_ptr<runtime::scope> const& scope = nullptr) const;
+        values::value execute(
+            runtime::resource const& resource,
+            std::function<lexer::position(std::string const&)> const& attribute_name_position,
+            std::function<lexer::position(std::string const&)> const& attribute_value_position,
+            std::shared_ptr<runtime::scope> const& scope = nullptr) const;
 
      private:
-        void validate_parameter(ast::parameter const& parameter, values::value const& value) const;
+        void validate_parameter(ast::parameter const& parameter, values::value const& value, boost::optional<lexer::position> const& value_position) const;
         values::value evaluate_body() const;
 
         expression_evaluator& _evaluator;

--- a/lib/include/puppet/runtime/scope.hpp
+++ b/lib/include/puppet/runtime/scope.hpp
@@ -23,19 +23,19 @@ namespace puppet { namespace runtime {
          * @param path The path of the file where the variable was assigned.
          * @param line The line where the variable was assigned.
          */
-        assigned_variable(values::value value, std::shared_ptr<std::string> path, size_t line);
+        assigned_variable(std::shared_ptr<values::value const> value, std::shared_ptr<std::string> path, size_t line);
 
         /**
          * Gets the value of the variable.
          * @return Returns the value of the variable.
          */
-        values::value const& value() const;
+        std::shared_ptr<values::value const> const& value() const;
 
         /**
          * Gets the path of the file where the variable was assigned.
          * @return Returns the path of the file where the variable was assigned.
          */
-        std::string const& path() const;
+        std::string const* path() const;
 
         /**
          * Gets the line where the variable was assigned.
@@ -44,7 +44,7 @@ namespace puppet { namespace runtime {
         size_t line() const;
 
      private:
-        values::value _value;
+        std::shared_ptr<values::value const> _value;
         std::shared_ptr<std::string> _path;
         size_t _line;
     };
@@ -95,7 +95,7 @@ namespace puppet { namespace runtime {
          * @param line The line number where the variable is being assigned or 0 if unknown.
          * @return Returns a pointer to the assigned variable or nullptr if the variable already exists in the scope.
          */
-        assigned_variable const* set(std::string name, values::value value, std::shared_ptr<std::string> path = nullptr, size_t line = 0);
+        assigned_variable const* set(std::string name, std::shared_ptr<values::value const> value, std::shared_ptr<std::string> path = nullptr, size_t line = 0);
 
         /**
          * Gets a variable in the scope.

--- a/lib/include/puppet/runtime/types/class.hpp
+++ b/lib/include/puppet/runtime/types/class.hpp
@@ -43,6 +43,15 @@ namespace puppet { namespace runtime { namespace types {
         }
 
         /**
+         * Determines if the class type is fully qualified.
+         * @return Returns true if the class type is fully qualified or false if not.
+         */
+        bool fully_qualified() const
+        {
+            return !_title.empty();
+        }
+
+        /**
          * Gets the name of the type.
          * @return Returns the name of the type (i.e. Class).
          */

--- a/lib/include/puppet/runtime/types/resource.hpp
+++ b/lib/include/puppet/runtime/types/resource.hpp
@@ -62,6 +62,24 @@ namespace puppet { namespace runtime { namespace types {
         }
 
         /**
+         * Determines if the resource type is fully qualified.
+         * @return Returns true if the resource type is fully qualified or false if not.
+         */
+        bool fully_qualified() const
+        {
+            return !_type_name.empty() && !_title.empty();
+        }
+
+        /**
+         * Determines if the resource is a class.
+         * @return Returns true if the resource is a class or false if not.
+         */
+        bool is_class() const
+        {
+            return _type_name == "Class";
+        }
+
+        /**
          * Gets the name of the type.
          * @return Returns the name of the type (i.e. Resource).
          */

--- a/lib/include/puppet/runtime/values/value.hpp
+++ b/lib/include/puppet/runtime/values/value.hpp
@@ -173,11 +173,12 @@ namespace puppet { namespace runtime { namespace values {
     bool is_specialization(type const& first, type const& second);
 
     /**
-     * Converts a value to an array (creates a copy of the value if already an array).
-     * @param val The value to convert.
+     * Converts the given value to an array; the value is returned as an array if already an array.
+     * @param val The value to convert to an array.
+     * @param convert_hash True if hashes should be converted to an array of name-value arrays or false if not.
      * @return Returns the converted array.
      */
-    array to_array(value const& val);
+    array to_array(value& val, bool convert_hash = true);
 
     /**
      * Joins the array by converting each element to a string.

--- a/lib/include/puppet/runtime/values/value.hpp
+++ b/lib/include/puppet/runtime/values/value.hpp
@@ -90,6 +90,15 @@ namespace puppet { namespace runtime { namespace values {
     }
 
     /**
+     * This exists to prevent unintentional invocations of the "as<T>" function.
+     * Because a value can be a bool and pointers are implicitly convertable to bool,
+     * calling as<T>(&val) results in constructing a temporary value that is set to "true".
+     * This function is declared without a definition to induce build errors if invoked.
+     */
+    template <typename T>
+    T const* as(value const*);
+
+    /**
      * Prepares the value for mutation as the given type.
      * Note: throws boost::bad_get if the value is not of the given type.
      * @tparam T The resulting type.

--- a/lib/include/puppet/runtime/values/variable.hpp
+++ b/lib/include/puppet/runtime/values/variable.hpp
@@ -7,13 +7,12 @@
 #include "../../cast.hpp"
 #include <boost/functional/hash.hpp>
 #include <ostream>
+#include <memory>
 
 namespace puppet { namespace runtime { namespace values {
 
     /**
      * Represents a reference to a variable.
-     * Having this as a runtime value prevents unnecessary copying of a variable's value.
-     * Thus, '$a = $b' simply points $a's value at what $b was set to.
      * @tparam Value The runtime value type.
      */
     template <typename Value>
@@ -27,13 +26,11 @@ namespace puppet { namespace runtime { namespace values {
         /**
          * Constructs a variable reference.
          * @param name The name of the variable.
-         * @param val The current value of the variable.
-         * @param match The variable is a match variable.
+         * @param value The variable's value.
          */
-        basic_variable(std::string name, value_type const* val, bool match) :
+        basic_variable(std::string name, std::shared_ptr<value_type const> value) :
             _name(rvalue_cast(name)),
-            _value(val),
-            _match(match)
+            _value(rvalue_cast(value))
         {
         }
 
@@ -56,28 +53,23 @@ namespace puppet { namespace runtime { namespace values {
             return _value ? *_value : undefined;
         }
 
-        /**
-         * Determines if the variable is a match variable.
-         * @return Returns true if the variable is a match variable or false if not.
-         */
-        bool match() const
+        std::shared_ptr<value_type const> const& value_ptr() const
         {
-            return _match;
+            return _value;
         }
 
         /**
-         * Updates the value of the variable.
-         * @param ptr The pointer to the variable's value.
+         * Assigns the given value to the variable.
+         * @param value The new value of the variable.
          */
-        void update(value_type const* ptr)
+        void assign(std::shared_ptr<value_type const> const& value)
         {
-            _value = ptr;
+            _value = value;
         }
 
     private:
         std::string _name;
-        value_type const* _value;
-        bool _match;
+        std::shared_ptr<value_type const> _value;
     };
 
     /**

--- a/lib/src/ast/case_expression.cc
+++ b/lib/src/ast/case_expression.cc
@@ -22,21 +22,9 @@ namespace puppet { namespace ast {
         }
     }
 
-    case_proposition::case_proposition(ast::lambda option, optional<vector<expression>> body) :
-        _lambda(rvalue_cast(option)),
-        _body(rvalue_cast(body))
-    {
-        _position = _lambda->position();
-    }
-
     vector<expression> const& case_proposition::options() const
     {
         return _options;
-    }
-
-    optional<ast::lambda> const& case_proposition::lambda() const
-    {
-        return _lambda;
     }
 
     optional<vector<expression>> const& case_proposition::body() const

--- a/lib/src/ast/resource_expression.cc
+++ b/lib/src/ast/resource_expression.cc
@@ -122,7 +122,7 @@ namespace puppet { namespace ast {
         return _type;
     }
 
-    vector<resource_body> resource_expression::bodies() const
+    vector<resource_body> const& resource_expression::bodies() const
     {
         return _bodies;
     }

--- a/lib/src/ast/resource_expression.cc
+++ b/lib/src/ast/resource_expression.cc
@@ -110,14 +110,14 @@ namespace puppet { namespace ast {
     {
     }
 
-    resource_expression::resource_expression(ast::name type, vector<resource_body> bodies, resource_status status) :
+    resource_expression::resource_expression(ast::primary_expression type, vector<resource_body> bodies, resource_status status) :
         _type(rvalue_cast(type)),
         _bodies(rvalue_cast(bodies)),
         _status(status)
     {
     }
 
-    ast::name const& resource_expression::type() const
+    ast::primary_expression const& resource_expression::type() const
     {
         return _type;
     }
@@ -134,12 +134,12 @@ namespace puppet { namespace ast {
 
     lexer::position const& resource_expression::position() const
     {
-        return _type.position();
+        return get_position(_type);
     }
 
     ostream& operator<<(ostream& os, resource_expression const& expression)
     {
-        if (expression.type().value().empty()) {
+        if (is_blank(expression.type())) {
             return os;
         }
         if (expression.status() == resource_status::virtualized) {

--- a/lib/src/runtime/definition_scanner.cc
+++ b/lib/src/runtime/definition_scanner.cc
@@ -72,9 +72,6 @@ namespace puppet { namespace runtime {
             operator()(expr.expression());
 
             for (auto const& proposition : expr.propositions()) {
-                if (proposition.lambda()) {
-                    operator()(*proposition.lambda());
-                }
                 for (auto const& option : proposition.options()) {
                     operator()(option);
                 }

--- a/lib/src/runtime/evaluators/basic.cc
+++ b/lib/src/runtime/evaluators/basic.cc
@@ -69,15 +69,17 @@ namespace puppet { namespace runtime { namespace evaluators {
     {
         auto& name = var.name();
 
-        bool match = false;
-        value const* val = nullptr;
-        if (!name.empty() && isdigit(name[0])) {
-            match = true;
-            val = _evaluator.context().lookup(stoi(name));
-        } else {
-            val = _evaluator.context().lookup(name, &_evaluator, &var.position());
+        if (name.empty()) {
+            throw evaluation_exception(var.position(), "variable name cannot be empty.");
         }
-        return variable(name, val, match);
+
+        shared_ptr<values::value const> value;
+        if (isdigit(name[0])) {
+            value = _evaluator.context().lookup(stoi(name));
+        } else {
+            value = _evaluator.context().lookup(name, &_evaluator, &var.position());
+        }
+        return values::variable(name, rvalue_cast(value));
     }
 
     basic_expression_evaluator::result_type basic_expression_evaluator::operator()(ast::name const& name)

--- a/lib/src/runtime/evaluators/catalog.cc
+++ b/lib/src/runtime/evaluators/catalog.cc
@@ -5,6 +5,7 @@
 using namespace std;
 using namespace puppet::lexer;
 using namespace puppet::runtime::values;
+using boost::optional;
 
 namespace puppet { namespace runtime { namespace evaluators {
 
@@ -24,30 +25,27 @@ namespace puppet { namespace runtime { namespace evaluators {
 
     catalog_expression_evaluator::result_type catalog_expression_evaluator::operator()(ast::resource_expression const& expr)
     {
-        auto catalog = _evaluator.catalog();
-
         // Evaluate the type name
         string type_name;
         auto type_value = _evaluator.evaluate(expr.type());
 
         // Resource expressions support either strings or Resource[Type] for the type name
+        bool is_class = false;
         if (as<std::string>(type_value)) {
             type_name = mutate_as<string>(type_value);
+            is_class = type_name == "class";
         } else if (auto type = as<values::type>(type_value)) {
             if (auto resource_type = boost::get<types::resource>(type)) {
                 if (resource_type->title().empty()) {
                     type_name = resource_type->type_name();
+                    is_class = resource_type->is_class();
                 }
             }
         }
 
+        // Ensure there was a valid type name
         if (type_name.empty()) {
             throw evaluation_exception(expr.position(), (boost::format("expected %1% or qualified %2% for resource type but found %3%.") % types::string::name() % types::resource::name() % get_type(type_value)).str());
-        }
-
-        // Handle class resources specially
-        if (type_name == "class") {
-            return declare_classes(expr);
         }
 
         if (expr.status() == ast::resource_status::virtualized) {
@@ -59,70 +57,71 @@ namespace puppet { namespace runtime { namespace evaluators {
             throw evaluation_exception(expr.position(), "exported resource expressions are not yet implemented.");
         }
 
-        // Handle defined types
-        if (catalog->is_defined_type(type_name)) {
-            return declare_defined_types(expr, type_name);
-        }
+        auto catalog = _evaluator.catalog();
+        bool is_defined_type = !is_class && catalog->is_defined_type(type_name);
 
+        // Evaluate the default attributes
+        auto default_body = find_default_body(expr);
+        auto defaults = evaluate_attributes(default_body);
+
+        // Evaluate each body
         values::array types;
-        vector<resource*> resources;
         for (auto const& body : expr.bodies()) {
             // Evaluate the title
             auto title = _evaluator.evaluate(body.title());
 
-            // Add a resource for each string in the title
-            resources.clear();
-            if (!for_each<string>(title, [&](string& resource_title) {
-                types::resource type(type_name, resource_title);
-                if (type.title().empty()) {
-                    throw evaluation_exception(body.position(), "resource title cannot be empty.");
-                }
+            // Helpers for getting the attribute name/value position
+            auto attribute_name_position = [&](string const& name) {
+                return find_attribute_position(true, name, body, default_body);
+            };
+            auto attribute_value_position = [&](string const& name) {
+                return find_attribute_position(false, name, body, default_body);
+            };
 
-                // Add the resource to the catalog
-                auto resource = catalog->add_resource(type, _evaluator.path(), body.position().line());
-                if (!resource) {
-                    resource = catalog->find_resource(type);
-                    if (resource) {
-                        throw evaluation_exception(body.position(), (boost::format("resource %1% was previously declared at %2%:%3%.") % type % resource->path() % resource->line()).str());
-                    }
-                    throw evaluation_exception(body.position(), (boost::format("failed to add resource %1% to catalog.") % type).str());
-                }
-
-                // Add the resource and type to the bookkeeping lists
-                resources.push_back(resource);
-                types.emplace_back(rvalue_cast(type));
-            })) {
-                throw evaluation_exception(body.position(), (boost::format("expected %1% or %2% for resource title.") % types::string::name() % types::array(types::string())).str());
-            }
-            if (!body.attributes()) {
+            // Check for the default resource body and skip
+            if (is_default(title)) {
                 continue;
             }
 
-            // Set the parameters
-            for (auto const& attribute : *body.attributes()) {
-                // Ensure only assignment for resource bodies
-                if (attribute.op() != ast::attribute_operator::assignment) {
-                    throw evaluation_exception(attribute.position(), (boost::format("illegal attribute opereration '%1%': only '%2%' is supported in a resource expression.") % attribute.op() % ast::attribute_operator::assignment).str());
+            // Evaluate the attributes
+            auto attributes = evaluate_attributes(&body, defaults);
+
+            // Add each resource to the catalog
+            if (!for_each<string>(title, [&](string& resource_title) {
+                if (resource_title.empty()) {
+                    throw evaluation_exception(body.position(), "resource title cannot be empty.");
                 }
 
-                // Evaluate the attribute value
-                auto attribute_value = _evaluator.evaluate(attribute.value());
-
-                // Loop through each resource in this body
-                for (size_t i = 0; i < resources.size(); ++i) {
-                    auto& resource = *resources[i];
-
-                    // For the last resource, move the value; otherwise copy
-                    values::value value;
-                    if (i == resources.size() - 1) {
-                        value = rvalue_cast(attribute_value);
-                    } else {
-                        value = attribute_value;
+                types::resource type(type_name, rvalue_cast(resource_title));
+                runtime::resource* resource = nullptr;
+                if (is_class) {
+                    // Declare the class
+                    resource = catalog->declare_class(_evaluator.context(), types::klass(type.title()), _evaluator.path(), body.position().line(), attributes, attribute_name_position, attribute_value_position);
+                    if (!resource) {
+                        throw evaluation_exception(body.position(), (boost::format("failed to declare class '%1%'.") % type.title()).str());
                     }
-
-                    // Set the parameter in the resource
-                    resource.set_parameter(attribute.name().value(), attribute.name().position(), rvalue_cast(value), attribute.value().position());
+                } else if (is_defined_type) {
+                    // Declare the defined type
+                    resource = catalog->declare_defined_type(_evaluator.context(), type_name, type.title(), _evaluator.path(), body.position().line(), attributes, attribute_name_position, attribute_value_position);
+                    if (!resource) {
+                        throw evaluation_exception(body.position(), (boost::format("failed to declare defined type %1%.") % type).str());
+                    }
+                } else {
+                    // Add the resource to the catalog
+                    resource = catalog->add_resource(type, _evaluator.path(), body.position().line(), attributes);
+                    if (!resource) {
+                        resource = catalog->find_resource(type);
+                        if (resource) {
+                            throw evaluation_exception(body.position(), (boost::format("resource %1% was previously declared at %2%:%3%.") % type % resource->path() % resource->line()).str());
+                        }
+                        throw evaluation_exception(body.position(), (boost::format("failed to add resource %1% to catalog.") % type).str());
+                    }
                 }
+
+                // Add the type to the return value
+                types.emplace_back(rvalue_cast(type));
+            })) {
+                throw evaluation_exception(body.position(), (boost::format("expected %1% or %2% for resource title.") % types::string::name() % types::array(types::string())).str());
             }
         }
         return types;
@@ -145,8 +144,13 @@ namespace puppet { namespace runtime { namespace evaluators {
         if (!for_each<values::type>(reference, [&](values::type& resource_reference) {
             // Make sure the type is a qualified Resource type
             auto resource_type = boost::get<types::resource>(&resource_reference);
-            if (!resource_type || resource_type->type_name().empty() || resource_type->title().empty()) {
+            if (!resource_type || !resource_type->fully_qualified()) {
                 throw evaluation_exception(position, (boost::format("expected qualified %1% but found %2%.") % types::resource::name() % get_type(resource_reference)).str());
+            }
+
+            // Classes cannot be overridden
+            if (resource_type->is_class()) {
+                throw evaluation_exception(position, "cannot override attributes of a class resource.");
             }
 
             // Find the resource
@@ -162,8 +166,11 @@ namespace puppet { namespace runtime { namespace evaluators {
         if (expr.attributes()) {
             // Set the parameters
             for (auto const& attribute : *expr.attributes()) {
+
+                auto const& name = attribute.name();
+
                 // Evaluate the attribute value
-                auto attribute_value = _evaluator.evaluate(attribute.value());
+                auto attribute_value = evaluate_attribute(attribute);
 
                 // Loop through each resource
                 for (size_t i = 0; i < resources.size(); ++i) {
@@ -180,18 +187,28 @@ namespace puppet { namespace runtime { namespace evaluators {
                         value = attribute_value;
                     }
 
+                    // Make the resource attribute's unique as they're about to change
+                    resource.make_attributes_unique();
+                    auto& attributes = resource.attributes();
+
                     if (attribute.op() == ast::attribute_operator::assignment) {
-                        if (is_undef(value)) {
-                            if (!override) {
-                                throw evaluation_exception(attribute.name().position(), (boost::format("cannot remove attribute '%1%' from resource %2%.") % attribute.name() % resource.type()).str());
+                        if (!override && attributes.get(name.value())) {
+                            if (is_undef(value)) {
+                                throw evaluation_exception(name.position(), (boost::format("cannot remove attribute '%1%' from resource %2%.") % name % resource.type()).str());
                             }
-                            resource.remove_parameter(attribute.name().value());
-                            continue;
+                            throw evaluation_exception(name.position(), (boost::format("attribute '%1%' has already been set for resource %2%.") % name % resource.type()).str());
                         }
                         // Set the parameter in the resource
-                        resource.set_parameter(attribute.name().value(), attribute.name().position(), rvalue_cast(value), attribute.value().position());
+                        attributes.set(name.value(), rvalue_cast(value));
                     } else if (attribute.op() == ast::attribute_operator::append) {
-                        // TODO: append parameter
+                        if (!override && attributes.get(name.value())) {
+                            throw evaluation_exception(name.position(), (boost::format("attribute '%1%' has already been set for resource %2% and cannot be appended to.") % name % resource.type()).str());
+                        }
+                        if (!attributes.append(name.value(), rvalue_cast(value))) {
+                            throw evaluation_exception(name.position(), (boost::format("attribute '%1%' is not an array.") % name).str());
+                        }
+                    } else {
+                        throw runtime_error("invalid attribute operator");
                     }
                 }
             }
@@ -227,123 +244,128 @@ namespace puppet { namespace runtime { namespace evaluators {
         throw evaluation_exception(expr.position(), "collection expressions are not yet implemented.");
     }
 
-    catalog_expression_evaluator::result_type catalog_expression_evaluator::declare_classes(ast::resource_expression const& expr)
+    bool catalog_expression_evaluator::is_default_expression(ast::primary_expression const& expr)
     {
-        auto catalog = _evaluator.catalog();
-
-        if (expr.status() == ast::resource_status::virtualized) {
-            throw evaluation_exception(expr.position(), "class resources cannot be virtual.");
+        if (auto ptr = boost::get<ast::expression>(&expr)) {
+            return ptr->binary().empty() && is_default_expression(ptr->primary());
         }
-        if (expr.status() == ast::resource_status::exported) {
-            throw evaluation_exception(expr.position(), "class resources cannot be exported.");
+        if (auto ptr = boost::get<ast::basic_expression>(&expr)) {
+            return boost::get<ast::defaulted>(ptr);
         }
-
-        values::array types;
-        vector<string> class_names;
-        unordered_map<ast::name, values::value> attributes;
-        values::array parameters;
-        for (auto const& body : expr.bodies()) {
-            // Evaluate the title as class names
-            auto title = _evaluator.evaluate(body.title());
-            class_names.clear();
-            if (!for_each<string>(title, [&](string& resource_title) {
-                class_names.emplace_back(rvalue_cast(resource_title));
-            })) {
-                throw evaluation_exception(body.position(), (boost::format("expected %1% or %2% for resource title.") % types::string::name() % types::array(types::string())).str());
-            }
-
-            // For this body, evaluate all attributes
-            attributes.clear();
-            if (body.attributes()) {
-                for (auto const& attribute : *body.attributes()) {
-                    // Ensure only assignment for resource bodies
-                    if (attribute.op() != ast::attribute_operator::assignment) {
-                        throw evaluation_exception(attribute.position(), (boost::format("illegal attribute opereration '%1%': only '%2%' is supported in a resource expression.") % attribute.op() % ast::attribute_operator::assignment).str());
-                    }
-
-                    // Evaluate the attribute value
-                    if (!attributes.emplace(make_pair(attribute.name(), _evaluator.evaluate(attribute.value()))).second) {
-                        throw evaluation_exception(attribute.position(), (boost::format("attribute '%1%' already exists in this resource body.") % attribute.name()).str());
-                    }
-                }
-            }
-
-            // Declare the classes
-            for (auto& name : class_names) {
-                types::klass klass(rvalue_cast(name));
-                types::resource resource("class", klass.title());
-
-                // Ensure the resource doesn't already exist
-                if (auto existing = catalog->find_resource(resource)) {
-                    throw evaluation_exception(body.position(), (boost::format("class '%1%' was already declared at %2%:%3%.") % klass.title() % existing->path() % existing->line()).str());
-                }
-
-                // Ensure the class is defined
-                if (!catalog->is_class_defined(klass)) {
-                    throw evaluation_exception(body.position(), (boost::format("cannot declare class '%1%' because the class has not been defined.") % klass.title()).str());
-                }
-
-                // Declare the class
-                if (!catalog->declare_class(_evaluator.context(), klass, _evaluator.path(), body.position(), &attributes)) {
-                    throw evaluation_exception(body.position(), (boost::format("failed to declare class '%1%'.") % klass.title()).str());
-                }
-                types.emplace_back(rvalue_cast(resource));
-            }
-        }
-        return types;
+        return false;
     }
 
-    catalog_expression_evaluator::result_type catalog_expression_evaluator::declare_defined_types(ast::resource_expression const& expr, string const& type_name)
+    ast::resource_body const* catalog_expression_evaluator::find_default_body(ast::resource_expression const& expr)
     {
-        auto catalog = _evaluator.catalog();
-
-        values::array types;
-        vector<string> titles;
-        unordered_map<ast::name, values::value> attributes;
-        values::array parameters;
+        ast::resource_body const* default_body = nullptr;
         for (auto const& body : expr.bodies()) {
-            // Evaluate the titles
-            auto title = _evaluator.evaluate(body.title());
-            titles.clear();
-            if (!for_each<string>(title, [&](string& resource_title) {
-                titles.emplace_back(rvalue_cast(resource_title));
-            })) {
-                throw evaluation_exception(body.position(), (boost::format("expected %1% or %2% for resource title.") % types::string::name() % types::array(types::string())).str());
+            if (!is_default_expression(body.title())) {
+                continue;
             }
-
-            // For this body, evaluate all attributes
-            attributes.clear();
-            if (body.attributes()) {
-                for (auto const& attribute : *body.attributes()) {
-                    // Ensure only assignment for resource bodies
-                    if (attribute.op() != ast::attribute_operator::assignment) {
-                        throw evaluation_exception(attribute.position(), (boost::format("illegal attribute opereration '%1%': only '%2%' is supported in a resource expression.") % attribute.op() % ast::attribute_operator::assignment).str());
-                    }
-
-                    // Evaluate the attribute value
-                    if (!attributes.emplace(make_pair(attribute.name(), _evaluator.evaluate(attribute.value()))).second) {
-                        throw evaluation_exception(attribute.position(), (boost::format("attribute '%1%' already exists in this resource body.") % attribute.name()).str());
-                    }
-                }
+            if (default_body) {
+                throw evaluation_exception(body.position(), "only one default body is supported in a resource expression.");
             }
+            default_body = &body;
+        }
+        return default_body;
+    }
 
-            // Declare the resources
-            for (auto& title : titles) {
-                types::resource resource(type_name, title);
-
-                // Ensure the resource doesn't already exist
-                if (auto existing = catalog->find_resource(resource)) {
-                    throw evaluation_exception(body.position(), (boost::format("resource %1% was previously declared at %2%:%3%.") % resource % existing->path() % existing->line()).str());
+    shared_ptr<runtime::attributes> catalog_expression_evaluator::evaluate_attributes(ast::resource_body const* body, shared_ptr<runtime::attributes const> parent)
+    {
+        shared_ptr<runtime::attributes> attributes;
+        if (body && body->attributes() && !body->attributes()->empty()) {
+            attributes = make_shared<runtime::attributes>(rvalue_cast(parent));
+            for (auto const& attribute : *body->attributes()) {
+                // Ensure only assignment for resource bodies
+                if (attribute.op() != ast::attribute_operator::assignment) {
+                    throw evaluation_exception(attribute.position(), (boost::format("illegal attribute operation '%1%': only '%2%' is supported in a resource expression.") % attribute.op() % ast::attribute_operator::assignment).str());
                 }
 
-                // Declare the defined type
-                if (!catalog->declare_defined_type(_evaluator.context(), type_name, title, _evaluator.path(), body.position(), &attributes)) {
-                    throw evaluation_exception(body.position(), (boost::format("failed to declare defined type %1%.") % resource).str());
+                // Ensure the value doesn't exist locally on the attributes collection
+                if (attributes->get(attribute.name().value(), false)) {
+                    throw evaluation_exception(attribute.position(), (boost::format("attribute '%1%' already exists in this resource body.") % attribute.name()).str());
                 }
-                types.emplace_back(rvalue_cast(resource));
+
+                // Set the attribute
+                attributes->set(attribute.name().value(), evaluate_attribute(attribute));
             }
         }
-        return types;
+        return attributes;
     }
+
+    values::value catalog_expression_evaluator::evaluate_attribute(ast::attribute_expression const& attribute)
+    {
+        // Type information for metaparameters
+        static const values::type string_array_type = types::array(types::string());
+        static const values::type relationship_type = types::array(types::variant({ types::string(), types::catalog_entry() }));
+        static const values::type string_type = types::string();
+        static const values::type boolean_type = types::boolean();
+        static const values::type loglevel_type = types::enumeration(vector<string>({ "debug", "info", "notice", "warning", "err", "alert", "emerg", "crit", "verbose" }));
+        static const values::type audit_type = types::variant({ types::string(), string_array_type });
+
+        // Evaluate the value expression
+        auto value = _evaluator.evaluate(attribute.value());
+        bool converted = false;
+
+        auto const& name = attribute.name().value();
+
+        // Perform metaparameter checks
+        values::type const* type = nullptr;
+        if (name == "alias") {
+            type = &string_array_type;
+            converted = !as<values::array>(value);
+            value = to_array(value, false);
+        } else if (name == "audit") {
+            type = &audit_type;
+        } else if (name == "before" || name == "notify" || name == "require" || name == "subscribe") {
+            type = &relationship_type;
+            converted = !as<values::array>(value);
+            value = to_array(value, false);
+        } else if (name == "loglevel") {
+            type = &loglevel_type;
+        } else if (name == "noop") {
+            type = &boolean_type;
+        } else if (name == "schedule") {
+            type = &string_type;
+        } else if (name == "stage") {
+            type = &string_type;
+        } else if (name == "tag") {
+            type = &string_array_type;
+            converted = !as<values::array>(value);
+            value = to_array(value, false);
+        }
+
+        if (!type) {
+            // Not a metaparameter
+            // TODO: get the attribute type from the type's definition and validate
+            return value;
+        }
+
+        // Validate the type of the parameter
+        if (!is_instance(value, *type)) {
+            throw evaluation_exception(attribute.value().position(), (boost::format("expected %1% for attribute '%2%' but found %3%.") % *type % name % get_type(converted ? as<values::array>(value)->at(0) : value)).str());
+        }
+        return value;
+    }
+
+    lexer::position catalog_expression_evaluator::find_attribute_position(bool name_position, string const& name, ast::resource_body const& current, ast::resource_body const* default_body)
+    {
+        if (current.attributes()) {
+            for (auto const& attribute : *current.attributes()) {
+                if (attribute.name().value() == name) {
+                    return name_position ? attribute.name().position() : attribute.value().position();
+                }
+            }
+        }
+        if (default_body && default_body->attributes()) {
+            for (auto const& attribute : *default_body->attributes()) {
+                if (attribute.name().value() == name) {
+                    return name_position ? attribute.name().position() : attribute.value().position();
+                }
+            }
+        }
+        throw runtime_error("unexpected attribute name for position.");
+    }
+
 
 }}}  // namespace puppet::runtime::evaluators

--- a/lib/src/runtime/evaluators/control_flow.cc
+++ b/lib/src/runtime/evaluators/control_flow.cc
@@ -32,25 +32,6 @@ namespace puppet { namespace runtime { namespace evaluators {
         for (size_t i = 0; i < propositions.size(); ++i) {
             auto& proposition = propositions[i];
 
-            // Check for a lambda proposition
-            if (proposition.lambda()) {
-                // Automatically splat an array
-                values::array arguments;
-                if (auto ptr = as<values::array>(result)) {
-                    arguments = *ptr;
-                } else {
-                    arguments.push_back(result);
-                }
-
-                // Execute the lambda and execute the block if truthy
-                auto const& lambda = *proposition.lambda();
-                runtime::executor executor(_evaluator, proposition.position(), lambda.parameters(), lambda.body());
-                if (is_truthy(executor.execute(arguments))) {
-                    return execute_block(proposition.body());
-                }
-                continue;
-            }
-
             // Look for a match in the options
             for (auto& option : proposition.options()) {
                 // Evaluate the option

--- a/lib/src/runtime/functions/include.cc
+++ b/lib/src/runtime/functions/include.cc
@@ -40,7 +40,7 @@ namespace puppet { namespace runtime { namespace functions {
 
         result_type operator()(types::resource const& argument) const
         {
-            if (argument.type_name() != "Class") {
+            if (!argument.is_class()) {
                 throw evaluation_exception(_context.position(_index), (boost::format("expected Class %1% for argument but found %2%.") % types::resource::name() % argument).str());
             }
             declare_class(types::klass(argument.title()));
@@ -71,7 +71,7 @@ namespace puppet { namespace runtime { namespace functions {
                 throw evaluation_exception(_context.position(_index), (boost::format("cannot include class '%1%' because the class has not been defined.") % klass.title()).str());
             }
 
-            if (!catalog->declare_class(evaluator.context(), klass, evaluator.path(), _context.position(_index))) {
+            if (!catalog->declare_class(evaluator.context(), klass, evaluator.path(), _context.position(_index).line())) {
                 throw evaluation_exception(_context.position(_index), (boost::format("failed to include class '%1%'.") % klass.title()).str());
             }
         }

--- a/lib/src/runtime/functions/with.cc
+++ b/lib/src/runtime/functions/with.cc
@@ -9,7 +9,9 @@ namespace puppet { namespace runtime { namespace functions {
 
     value with::operator()(call_context& context) const
     {
-        return context.lambda().execute(context.arguments());
+        return context.lambda().execute(context.arguments(), [&](size_t index) {
+            return context.position(index);
+        });
     }
 
 }}}  // namespace puppet::runtime::functions

--- a/lib/src/runtime/operators/minus.cc
+++ b/lib/src/runtime/operators/minus.cc
@@ -68,7 +68,7 @@ namespace puppet { namespace runtime { namespace operators {
         {
             // Remove any [K,V] elements in left that are key and value in right
             left.erase(remove_if(left.begin(), left.end(), [&](value const& v) {
-                auto ptr = as<values::array>(&v);
+                auto ptr = as<values::array>(v);
                 if (!ptr || ptr->size() != 2) {
                     return false;
                 }

--- a/lib/src/runtime/operators/splat.cc
+++ b/lib/src/runtime/operators/splat.cc
@@ -8,10 +8,7 @@ namespace puppet { namespace runtime { namespace operators {
 
     value splat::operator()(unary_context& context) const
     {
-        if (as<values::array>(context.operand())) {
-            return mutate(context.operand());
-        }
-        return to_array(dereference(context.operand()));
+        return values::to_array(context.operand());
     }
 
 }}}  // namespace puppet::runtime::operators

--- a/lib/src/runtime/scope.cc
+++ b/lib/src/runtime/scope.cc
@@ -7,7 +7,7 @@ using namespace puppet::runtime::values;
 
 namespace puppet { namespace runtime {
 
-    assigned_variable::assigned_variable(values::value value, shared_ptr<string> path, size_t line) :
+    assigned_variable::assigned_variable(shared_ptr<values::value const> value, shared_ptr<string> path, size_t line) :
         _value(rvalue_cast(value)),
         _path(rvalue_cast(path)),
         _line(line)
@@ -17,14 +17,14 @@ namespace puppet { namespace runtime {
         }
     }
 
-    values::value const& assigned_variable::value() const
+    shared_ptr<value const> const& assigned_variable::value() const
     {
         return _value;
     }
 
-    string const& assigned_variable::path() const
+    string const* assigned_variable::path() const
     {
-        return *_path;
+        return _path.get();
     }
 
     size_t assigned_variable::line() const
@@ -73,7 +73,7 @@ namespace puppet { namespace runtime {
         return scope_name + "::" + name;
     }
 
-    assigned_variable const* scope::set(string name, values::value value, shared_ptr<string> path, size_t line)
+    assigned_variable const* scope::set(string name, shared_ptr<values::value const> value, shared_ptr<string> path, size_t line)
     {
         if (_variables.count(name)) {
             return nullptr;

--- a/lib/src/runtime/string_interpolator.cc
+++ b/lib/src/runtime/string_interpolator.cc
@@ -45,9 +45,6 @@ namespace puppet { namespace runtime {
             bool bracket = begin != end && *begin == '{';
             string_static_lexer lexer;
 
-            // Check for keyword or name
-            value const* val = nullptr;
-
             auto current = begin;
             auto token_begin = lexer.begin(current, end);
             auto token_end = lexer.end();
@@ -61,6 +58,7 @@ namespace puppet { namespace runtime {
                 ++token_begin;
             }
 
+            shared_ptr<values::value const> value;
             if (token_begin != token_end &&
                 (
                     is_keyword(static_cast<token_id>(token_begin->id())) ||
@@ -71,7 +69,7 @@ namespace puppet { namespace runtime {
                 if (!token) {
                     return false;
                 }
-                val = context.lookup(string(token->begin(), token->end()), &evaluator, &position);
+                value = context.lookup(string(token->begin(), token->end()), &evaluator, &position);
             } else if (token_begin != token_end && token_begin->id() == static_cast<size_t>(token_id::number)) {
                 auto token = get<number_token>(&token_begin->value());
                 if (!token) {
@@ -80,7 +78,7 @@ namespace puppet { namespace runtime {
                 if (token->base() != numeric_base::decimal || token->value().which() != 0) {
                     throw evaluation_exception(position, (boost::format("'%1%' is not a valid match variable name.") % *token).str());
                 }
-                val = context.lookup(get<int64_t>(token->value()));
+                value = context.lookup(get<int64_t>(token->value()));
             } else {
                 return false;
             }
@@ -96,9 +94,9 @@ namespace puppet { namespace runtime {
             }
 
             // Output the variable
-            if (val) {
+            if (value) {
                 ostringstream ss;
-                ss << *val;
+                ss << *value;
                 result += ss.str();
             }
 

--- a/lib/src/runtime/values/value.cc
+++ b/lib/src/runtime/values/value.cc
@@ -214,19 +214,18 @@ namespace puppet { namespace runtime { namespace values {
         return boost::apply_visitor(is_specialization_visitor(second), first);
     }
 
-    array to_array(value const& val)
+    array to_array(value& val, bool convert_hash)
     {
         // If already an array, return a copy
-        auto array_ptr = as<values::array>(val);
-        if (array_ptr) {
-            return *array_ptr;
+        if (as<values::array>(val)) {
+            return mutate_as<values::array>(val);
         }
 
         array result;
 
         // Check for hash
         auto hash_ptr = as<values::hash>(val);
-        if (hash_ptr) {
+        if (convert_hash && hash_ptr) {
             // Turn the hash into an array of [K,V]
             for (auto& kvp : *hash_ptr) {
                 array element;
@@ -234,7 +233,7 @@ namespace puppet { namespace runtime { namespace values {
                 element.emplace_back(kvp.second);
                 result.emplace_back(rvalue_cast(element));
             }
-        } else {
+        } else if (!is_undef(val)) {
             // Otherwise, add the value as the only element
             result.emplace_back(val);
         }

--- a/lib/src/runtime/values/value.cc
+++ b/lib/src/runtime/values/value.cc
@@ -217,7 +217,7 @@ namespace puppet { namespace runtime { namespace values {
     array to_array(value const& val)
     {
         // If already an array, return a copy
-        auto array_ptr = as<values::array>(&val);
+        auto array_ptr = as<values::array>(val);
         if (array_ptr) {
             return *array_ptr;
         }
@@ -225,7 +225,7 @@ namespace puppet { namespace runtime { namespace values {
         array result;
 
         // Check for hash
-        auto hash_ptr = as<values::hash>(&val);
+        auto hash_ptr = as<values::hash>(val);
         if (hash_ptr) {
             // Turn the hash into an array of [K,V]
             for (auto& kvp : *hash_ptr) {

--- a/lib/src/runtime/values/value.cc
+++ b/lib/src/runtime/values/value.cc
@@ -146,7 +146,7 @@ namespace puppet { namespace runtime { namespace values {
 
         result_type operator()(type const& t) const
         {
-            return t;
+            return types::type(t);
         }
 
         result_type operator()(variable const& var) const


### PR DESCRIPTION
This implements the following:

* Implement Type and Resource['type'] in resource expressions.
* Implement support for resource expression default attributes.
* Implement resource metaparameter type checking.
* Implement stricter checks of class/defined type parameters.
* Implement attribute sharing between resources that are declared in the
  same expressions.
* Implement setting all resource attributes in a class / define type's
  evaluation scope.
* Improve error messages for class/defined type attributes with
  mismatched types.

This fixes the following:

* Fix bug where as<T> was being invoked with pointers to values instead of refs.
* Fix resource expression bodies being unnecessarily copied during
  evaluation.
* Fix splat of undef (correct: [], incorrect: [undef])
* Fix variable value ref counting.

This removes the following:

* Support for lambdas as case options; this was removed from Puppet.