### PR TITLE
(runtime) Fix typo in the dispatcher

### DIFF
--- a/lib/include/puppet/compiler/node.hpp
+++ b/lib/include/puppet/compiler/node.hpp
@@ -7,6 +7,7 @@
 #include "exceptions.hpp"
 #include "settings.hpp"
 #include "../runtime/catalog.hpp"
+#include "../runtime/context.hpp"
 #include "../logging/logger.hpp"
 #include "environment.hpp"
 #include <exception>
@@ -55,6 +56,9 @@ namespace puppet { namespace compiler {
         void each_name(std::function<bool(std::string const&)> const& callback) const;
 
      private:
+        static void create_main(runtime::catalog& catalog);
+        static void create_settings_scope(runtime::context& context, compiler::settings const& settings);
+
         std::set<std::string> _names;
         compiler::environment& _environment;
     };

--- a/lib/include/puppet/runtime/call_context.hpp
+++ b/lib/include/puppet/runtime/call_context.hpp
@@ -74,16 +74,36 @@ namespace puppet { namespace runtime {
         values::array& arguments();
 
         /**
-         * Gets the executor for the lambda.
-         * @return Returns the executor for the lambda.
-         */
-        runtime::executor const& lambda() const;
-
-        /**
          * Determines if a lambda was passed to the function.
          * @return Returns true if a lambda was passed or false if one was not.
          */
         bool lambda_given() const;
+
+        /**
+         * Gets the count the lambda's parameters.
+         * @return Returns the number of lambda parameters or 0 if no lambda was given.
+         */
+        size_t lambda_parameter_count() const;
+
+        /**
+         * Gets the position of the lambda if one was passed.
+         * @return Returns the position of the lambda passed to the function or the position of the function call if one was not passed.
+         */
+        lexer::position const& lambda_position() const;
+
+        /**
+         * Yields to the lambda if one is present.
+         * @param arguments The arguments to yield to the lambda.
+         * @return Returns the value that was returned by the lambda.
+         */
+        values::value yield(values::array& arguments) const;
+
+        /**
+         * Yields to the lambda if one is present, without catching argument exceptions.
+         * @param arguments The arguments to yield to the lambda.
+         * @return Returns the value that was returned by the lambda.
+         */
+        values::value yield_without_catch(values::array& arguments) const;
 
     private:
         expression_evaluator& _evaluator;
@@ -91,7 +111,7 @@ namespace puppet { namespace runtime {
         lexer::position const& _position;
         values::array _arguments;
         std::vector<lexer::position> _positions;
-        runtime::executor _executor;
+        runtime::executor _lambda;
         bool _lambda_given;
     };
 

--- a/lib/include/puppet/runtime/context.hpp
+++ b/lib/include/puppet/runtime/context.hpp
@@ -70,9 +70,9 @@ namespace puppet { namespace runtime {
         /**
          * Constructs a node scope.
          * @param context The current evaluation context.
-         * @param name The name of the node scope.
+         * @param resource The node resource.
          */
-        node_scope(runtime::context& context, std::string name);
+        node_scope(runtime::context& context, runtime::resource* resource);
 
         /**
          * Destructs the node scope.
@@ -126,7 +126,7 @@ namespace puppet { namespace runtime {
         std::shared_ptr<runtime::scope> const& node_or_top();
 
         /**
-         * Adds a scope to the evaluation context.
+         * Adds a named scope to the evaluation context.
          * @param scope The scope to add to the evaluation context.
          * @return Returns true if the scope was added or false if the scope already exists.
          */

--- a/lib/include/puppet/runtime/definition_scanner.hpp
+++ b/lib/include/puppet/runtime/definition_scanner.hpp
@@ -4,30 +4,37 @@
  */
 #pragma once
 
-#include "../ast/syntax_tree.hpp"
-#include "catalog.hpp"
 #include <memory>
+
+namespace puppet { namespace compiler {
+
+    // Forward declaration of compiler context.
+    struct context;
+
+}}  // namespace puppet::compiler
 
 namespace puppet { namespace runtime {
 
+    // Forward declaration of catalog.
+    struct catalog;
+
     /**
      * Represents the runtime definition scanner.
-     * This type is responsible for scanning a syntax tree and
-     * defining classes, defined types, and nodes in a catalog.
+     * This type is responsible for scanning a syntax tree for catalog-related definitions.
      */
     struct definition_scanner
     {
         /**
          * Constructs a definition scanner.
-         * @param catalog The catalog to populate with definitions.
+         * @param catalog The catalog to populate with class, defined type, and node definitions.
          */
         explicit definition_scanner(runtime::catalog& catalog);
 
         /**
-         * Scans the given compilation context's syntax tree for definition.
-         * @param compilation_context The compilation context.
+         * Scans the given compilation context's syntax tree for definitions.
+         * @param context The compilation context to scan.
          */
-        void scan(std::shared_ptr<compiler::context> compilation_context);
+        void scan(std::shared_ptr<compiler::context> const& context);
 
      private:
         runtime::catalog& _catalog;

--- a/lib/include/puppet/runtime/executor.hpp
+++ b/lib/include/puppet/runtime/executor.hpp
@@ -8,11 +8,77 @@
 #include "expression_evaluator.hpp"
 #include <boost/optional.hpp>
 #include <vector>
-#include <functional>
 #include <unordered_map>
 #include <string>
+#include <exception>
 
 namespace puppet { namespace runtime {
+
+    /**
+     * Exception for arguments passed by index.
+     */
+    struct argument_exception : std::runtime_error
+    {
+        /**
+         * Constructs a new argument exception.
+         * @param message The exception message.
+         * @param index The index of the argument.
+         */
+        argument_exception(std::string const& message, size_t index);
+
+        /**
+         * Gets the index of the argument that caused the exception.
+         * @return Returns the index of the argument that caused the exception.
+         */
+        size_t index() const;
+
+     private:
+        size_t _index;
+    };
+
+    /**
+     * Exception for attribute names.
+     */
+    struct attribute_name_exception : std::runtime_error
+    {
+        /**
+         * Constructs a new attribute name exception.
+         * @param message The exception message.
+         * @param name The name of the attribute.
+         */
+        attribute_name_exception(std::string const& message, std::string name);
+
+        /**
+         * Gets the name of the attribute that caused the exception.
+         * @return Returns the name of the attribute that caused the exception.
+         */
+        std::string const& name() const;
+
+     private:
+        std::string _name;
+    };
+
+    /**
+     * Exception for attribute values.
+     */
+    struct attribute_value_exception : std::runtime_error
+    {
+        /**
+         * Constructs a new attribute value exception.
+         * @param message The exception message.
+         * @param name The name of the attribute.
+         */
+        attribute_value_exception(std::string const& message, std::string name);
+
+        /**
+         * Gets the name of the attribute that caused the exception.
+         * @return Returns the name of the attribute that caused the exception.
+         */
+        std::string const& name() const;
+
+     private:
+        std::string _name;
+    };
 
     /**
      * Represents the runtime executor.
@@ -57,26 +123,18 @@ namespace puppet { namespace runtime {
         /**
          * Executes the expression with the given positional arguments.
          * @param arguments The positional arguments to set in the scope.
-         * @param create_exception The callback to use to create an exception for the given argument position and message.
          * @param scope The scope to execute under or nullptr to use an ephemeral scope.
          * @return Returns the value that was returned from the body.
          */
-        values::value execute(
-            values::array& arguments,
-            std::function<evaluation_exception(size_t, std::string)> const& create_exception = nullptr,
-            std::shared_ptr<runtime::scope> const& scope = nullptr) const;
+        values::value execute(values::array& arguments, std::shared_ptr<runtime::scope> const& scope = nullptr) const;
 
         /**
          * Executes the expression with the given resource's attributes.
          * @param resource The resource attributes to set in the scope.
-         * @param create_exception The callback to use to create an exception for the given argument name and message.
          * @param scope The scope to execute under or nullptr to use an ephemeral scope.
          * @return Returns the value that was returned from the body.
          */
-        values::value execute(
-            runtime::resource const& resource,
-            std::function<evaluation_exception(bool, std::string const&, std::string)> const& create_exception = nullptr,
-            std::shared_ptr<runtime::scope> const& scope = nullptr) const;
+        values::value execute(runtime::resource const& resource, std::shared_ptr<runtime::scope> const& scope = nullptr) const;
 
      private:
         void validate_type(ast::parameter const& parameter, values::value const& value, std::function<void(std::string)> const& type_error) const;

--- a/lib/include/puppet/runtime/expression_evaluator.hpp
+++ b/lib/include/puppet/runtime/expression_evaluator.hpp
@@ -7,6 +7,7 @@
 #include "../ast/syntax_tree.hpp"
 #include "../compiler/context.hpp"
 #include "context.hpp"
+#include <boost/optional.hpp>
 #include <cstdint>
 #include <vector>
 #include <exception>
@@ -21,12 +22,18 @@ namespace puppet { namespace runtime {
     struct evaluation_exception : std::runtime_error
     {
         /**
-         * Constructs an evaluator exception.
-         * @param context The compilation context where the evaluation failed.
-         * @param position The position where evaluation failed.
+         * Constructs an evaluation exception.
          * @param message The exception message.
          */
-        evaluation_exception(std::shared_ptr<compiler::context> context, lexer::position position, std::string const& message);
+        explicit evaluation_exception(std::string const& message);
+
+        /**
+         * Constructs an evaluation exception.
+         * @param message The exception message.
+         * @param context The compilation context where the evaluation failed.
+         * @param position The position where evaluation failed.
+         */
+        evaluation_exception(std::string const& message, std::shared_ptr<compiler::context> context, lexer::position position);
 
         /**
          * Gets the compilation context where evaluation failed.
@@ -58,28 +65,16 @@ namespace puppet { namespace runtime {
         expression_evaluator(std::shared_ptr<compiler::context> compilation_context, runtime::context& evaluation_context);
 
         /**
+         * Gets the current compilation context.
+         * @return Returns the current compilation context.
+         */
+        std::shared_ptr<compiler::context> const& compilation_context();
+
+        /**
          * Gets the current evaluation context.
          * @return Returns the current evaluation context.
          */
-        runtime::context& context();
-
-        /**
-         * Gets the catalog being compiled.
-         * @return Returns the catalog being compiled or nullptr if catalog expressions are not supported.
-         */
-        runtime::catalog* catalog();
-
-        /**
-         * Gets the logger.
-         * @return Returns the logger.
-         */
-        logging::logger& logger();
-
-        /**
-         * Gets the path to the file being evaluated.
-         * @return Returns the path to the file being evaluated.
-         */
-        std::shared_ptr<std::string> const& path() const;
+        runtime::context& evaluation_context();
 
         /**
          * Creates an evaluation exception with the given position and message.

--- a/lib/include/puppet/runtime/scope.hpp
+++ b/lib/include/puppet/runtime/scope.hpp
@@ -13,6 +13,9 @@
 
 namespace puppet { namespace runtime {
 
+    // Forward declaration of resource.
+    struct resource;
+
     /**
      * Represents an assigned variable.
      */
@@ -58,34 +61,29 @@ namespace puppet { namespace runtime {
         /**
          * Constructs a scope.
          * @param parent The parent scope.
-         * @param name The name of the scope (e.g. foo).
-         * @param display_name The display name of the scope (e.g. Class[foo]).
+         * @param resource The resource associated with the scope.
          */
-        explicit scope(std::shared_ptr<scope> parent, std::string name = std::string(), std::string display_name = std::string());
+        explicit scope(std::shared_ptr<scope> parent, runtime::resource* resource = nullptr);
 
         /**
          * Constructs the top scope.
          * @param facts The facts provider to use for the top scope.
+         * @param resource The resource associated with the top scope.
          */
-        explicit scope(std::shared_ptr<facts::provider> facts);
-
-        /**
-         * Gets the name of the scope.
-         * @return Returns the name of scope.
-         */
-        std::string const& name() const;
-
-        /**
-         * Gets the display name of the scope.
-         * @return Returns the display name of scope.
-         */
-        std::string const& display_name() const;
+        explicit scope(std::shared_ptr<facts::provider> facts, runtime::resource* resource = nullptr);
 
         /**
          * Gets the parent scope.
          * @return Returns the parent scope or nullptr if at top scope.
          */
         std::shared_ptr<scope> const& parent() const;
+
+        /**
+         * Gets the resource associated with the scope.
+         * Resources associated with a scope denote the container resource.
+         * @return Returns the resource associated with the scope or nullptr if there is no associated resource.
+         */
+        runtime::resource* resource() const;
 
         /**
          * Qualifies the given name using the scope's name.
@@ -114,8 +112,7 @@ namespace puppet { namespace runtime {
      private:
         std::shared_ptr<facts::provider> _facts;
         std::shared_ptr<scope> _parent;
-        std::string _name;
-        std::string _display_name;
+        runtime::resource* _resource;
         std::unordered_map<std::string, assigned_variable> _variables;
     };
 

--- a/lib/include/puppet/runtime/types/resource.hpp
+++ b/lib/include/puppet/runtime/types/resource.hpp
@@ -196,7 +196,7 @@ namespace puppet { namespace runtime { namespace types {
         if (type.title().empty()) {
             return os;
         }
-        os << "['" << type.title() << "']";
+        os << "[" << type.title() << "]";
         return os;
     }
 

--- a/lib/src/compiler/context.cc
+++ b/lib/src/compiler/context.cc
@@ -54,13 +54,14 @@ namespace puppet { namespace compiler {
 
     void context::log(logging::level level, lexer::position const& position, std::string const& message)
     {
+        if (!_logger.would_log(level)) {
+            return;
+        }
+
         string text;
         size_t column;
         tie(text, column) = get_text_and_column(_stream, position.offset());
-
-        if (_logger.would_log(level)) {
-            _logger.log(level, position.line(), column, text, *_path, "node '%1%': %2%", _node.name(), message);
-        }
+        _logger.log(level, position.line(), column, text, *_path, "node '%1%': %2%", _node.name(), message);
     }
 
     compilation_exception context::create_exception(lexer::position const& position, string const& message)

--- a/lib/src/runtime/dispatcher.cc
+++ b/lib/src/runtime/dispatcher.cc
@@ -47,7 +47,7 @@ namespace puppet { namespace runtime {
             _evaluator(evaluator),
             _name(name),
             _position(position),
-            _executor(evaluator, _position, lambda_parameters(lambda), lamda_body(lambda)),
+            _lambda(evaluator, _position, lambda_parameters(lambda), lamda_body(lambda)),
             _lambda_given(lambda)
     {
         _arguments.reserve((arguments ? arguments->size() : 0) + (first_value ? 1 : 0));
@@ -104,10 +104,10 @@ namespace puppet { namespace runtime {
         return _position;
     }
 
-        lexer::position const& call_context::position(size_t index) const
+    lexer::position const& call_context::position(size_t index) const
     {
         if (index >= _positions.size()) {
-            throw runtime_error("argument index out of range.");
+            return _position;
         }
         return _positions[index];
     }
@@ -122,14 +122,43 @@ namespace puppet { namespace runtime {
         return _arguments;
     }
 
-    runtime::executor const& call_context::lambda() const
-    {
-        return _executor;
-    }
-
     bool call_context::lambda_given() const
     {
         return _lambda_given;
+    }
+
+    size_t call_context::lambda_parameter_count() const
+    {
+        return _lambda.parameter_count();
+    }
+
+    lexer::position const& call_context::lambda_position() const
+    {
+        return _lambda.position();
+    }
+
+    values::value call_context::yield(values::array& arguments) const
+    {
+        if (!_lambda_given) {
+            return undef();
+        }
+
+        // Execute the lambda
+        try {
+            return _lambda.execute(arguments);
+        } catch (argument_exception const& ex) {
+            throw _evaluator.create_exception(_lambda.position(ex.index()), ex.what());
+        }
+    }
+
+    values::value call_context::yield_without_catch(values::array& arguments) const
+    {
+        if (!_lambda_given) {
+            return undef();
+        }
+
+        // Execute the lambda
+        return _lambda.execute(arguments);
     }
 
     dispatcher::dispatcher(expression_evaluator& evaluator, string const& name, lexer::position const& position) :
@@ -171,8 +200,9 @@ namespace puppet { namespace runtime {
         ast::primary_expression const* first_expression,
         lexer::position const* first_position) const
     {
-        // Dispatch the call
         call_context context(_evaluator, _name, _position, arguments, lambda, first_value, first_expression, first_position);
+
+        // Dispatch the call
         return (*_function)(context);
     }
 

--- a/lib/src/runtime/dispatcher.cc
+++ b/lib/src/runtime/dispatcher.cc
@@ -26,7 +26,7 @@ namespace puppet { namespace runtime {
         return lambda->parameters();
     }
 
-    static optional<vector<ast::expression>> const& lamda_body(optional<ast::lambda> const& lambda)
+    static optional<vector<ast::expression>> const& lambda_body(optional<ast::lambda> const& lambda)
     {
         static optional<vector<ast::expression>> none;
         if (!lambda) {
@@ -47,7 +47,7 @@ namespace puppet { namespace runtime {
             _evaluator(evaluator),
             _name(name),
             _position(position),
-            _lambda(evaluator, _position, lambda_parameters(lambda), lamda_body(lambda)),
+            _lambda(evaluator, _position, lambda_parameters(lambda), lambda_body(lambda)),
             _lambda_given(lambda)
     {
         _arguments.reserve((arguments ? arguments->size() : 0) + (first_value ? 1 : 0));

--- a/lib/src/runtime/evaluators/basic.cc
+++ b/lib/src/runtime/evaluators/basic.cc
@@ -73,11 +73,13 @@ namespace puppet { namespace runtime { namespace evaluators {
             throw _evaluator.create_exception(var.position(), "variable name cannot be empty.");
         }
 
+        auto& context = _evaluator.evaluation_context();
+
         shared_ptr<values::value const> value;
         if (isdigit(name[0])) {
-            value = _evaluator.context().lookup(stoi(name));
+            value = context.lookup(stoi(name));
         } else {
-            value = _evaluator.context().lookup(name, &_evaluator, &var.position());
+            value = context.lookup(name, &_evaluator, &var.position());
         }
         return values::variable(name, rvalue_cast(value));
     }

--- a/lib/src/runtime/evaluators/catalog.cc
+++ b/lib/src/runtime/evaluators/catalog.cc
@@ -92,12 +92,24 @@ namespace puppet { namespace runtime { namespace evaluators {
                 types::resource type(type_name, rvalue_cast(resource_title));
                 runtime::resource* resource = nullptr;
                 if (is_class) {
+                    // Ensure the class hasn't already been declared
+                    resource = catalog->find_resource(type);
+                    if (resource) {
+                        throw _evaluator.create_exception(body.position(), (boost::format("class '%1%' was previously declared at %2%:%3%.") % type.title() % *resource->path() % resource->line()).str());
+                    }
+
                     // Declare the class
                     resource = catalog->declare_class(_evaluator.context(), types::klass(type.title()), _evaluator.path(), body.position().line(), attributes, create_exception);
                     if (!resource) {
                         throw _evaluator.create_exception(body.position(), (boost::format("failed to declare class '%1%'.") % type.title()).str());
                     }
                 } else if (is_defined_type) {
+                    // Ensure the defined type hasn't already been declared
+                    resource = catalog->find_resource(type);
+                    if (resource) {
+                        throw _evaluator.create_exception(body.position(), (boost::format("defined type '%1%' was previously declared at %2%:%3%.") % type.title() % *resource->path() % resource->line()).str());
+                    }
+
                     // Declare the defined type
                     resource = catalog->declare_defined_type(_evaluator.context(), type_name, type.title(), _evaluator.path(), body.position().line(), attributes, create_exception);
                     if (!resource) {
@@ -109,7 +121,7 @@ namespace puppet { namespace runtime { namespace evaluators {
                     if (!resource) {
                         resource = catalog->find_resource(type);
                         if (resource) {
-                            throw _evaluator.create_exception(body.position(), (boost::format("resource %1% was previously declared at %2%:%3%.") % type % resource->path() % resource->line()).str());
+                            throw _evaluator.create_exception(body.position(), (boost::format("resource %1% was previously declared at %2%:%3%.") % type % *resource->path() % resource->line()).str());
                         }
                         throw _evaluator.create_exception(body.position(), (boost::format("failed to add resource %1% to catalog.") % type).str());
                     }

--- a/lib/src/runtime/evaluators/control_flow.cc
+++ b/lib/src/runtime/evaluators/control_flow.cc
@@ -22,7 +22,7 @@ namespace puppet { namespace runtime { namespace evaluators {
     control_flow_expression_evaluator::result_type control_flow_expression_evaluator::operator()(ast::case_expression const& expr)
     {
         // Case expressions create a new match scope
-        auto match_scope = _evaluator.context().create_match_scope();
+        auto match_scope = _evaluator.evaluation_context().create_match_scope();
 
         // Evaluate the case's expression
         value result = _evaluator.evaluate(expr.expression());
@@ -70,7 +70,7 @@ namespace puppet { namespace runtime { namespace evaluators {
     control_flow_expression_evaluator::result_type control_flow_expression_evaluator::operator()(ast::if_expression const& expr)
     {
         // If expressions create a new match scope
-        auto match_scope = _evaluator.context().create_match_scope();
+        auto match_scope = _evaluator.evaluation_context().create_match_scope();
 
         if (is_truthy(_evaluator.evaluate(expr.conditional()))) {
             return execute_block(expr.body());
@@ -91,7 +91,7 @@ namespace puppet { namespace runtime { namespace evaluators {
     control_flow_expression_evaluator::result_type control_flow_expression_evaluator::operator()(ast::unless_expression const& expr)
     {
         // Unless expressions create a new match scope
-        auto match_scope = _evaluator.context().create_match_scope();
+        auto match_scope = _evaluator.evaluation_context().create_match_scope();
 
         if (!is_truthy(_evaluator.evaluate(expr.conditional()))) {
             return execute_block(expr.body());

--- a/lib/src/runtime/evaluators/postfix.cc
+++ b/lib/src/runtime/evaluators/postfix.cc
@@ -34,7 +34,7 @@ namespace puppet { namespace runtime { namespace evaluators {
     postfix_expression_evaluator::result_type postfix_expression_evaluator::operator()(ast::selector_expression const& expr)
     {
         // Selector expressions create a new match scope
-        auto match_scope = _evaluator.context().create_match_scope();
+        auto match_scope = _evaluator.evaluation_context().create_match_scope();
 
         boost::optional<size_t> default_index;
 

--- a/lib/src/runtime/functions/assert_type.cc
+++ b/lib/src/runtime/functions/assert_type.cc
@@ -34,7 +34,7 @@ namespace puppet { namespace runtime { namespace functions {
         }
 
         arguments[1] = get_type(arguments[1]);
-        return context.lambda().execute(arguments);
+        return context.yield(arguments);
     }
 
 }}}  // namespace puppet::runtime::functions

--- a/lib/src/runtime/functions/each.cc
+++ b/lib/src/runtime/functions/each.cc
@@ -20,13 +20,13 @@ namespace puppet { namespace runtime { namespace functions {
             arguments.reserve(2);
             for (size_t i = 0; i < argument.size(); ++i) {
                 arguments.clear();
-                if (_context.lambda().parameter_count() == 1) {
+                if (_context.lambda_parameter_count() == 1) {
                     arguments.push_back(string(1, argument[i]));
                 } else {
                     arguments.push_back(static_cast<int64_t>(i));
                     arguments.push_back(string(1, argument[i]));
                 }
-                _context.lambda().execute(arguments);
+                _context.yield(arguments);
             }
         }
 
@@ -43,13 +43,13 @@ namespace puppet { namespace runtime { namespace functions {
             arguments.reserve(2);
             for (size_t i = 0; i < argument.size(); ++i) {
                 arguments.clear();
-                if (_context.lambda().parameter_count() == 1) {
+                if (_context.lambda_parameter_count() == 1) {
                     arguments.push_back(argument[i]);
                 } else {
                     arguments.push_back(static_cast<int64_t>(i));
                     arguments.push_back(argument[i]);
                 }
-                _context.lambda().execute(arguments);
+                _context.yield(arguments);
             }
         }
 
@@ -59,13 +59,13 @@ namespace puppet { namespace runtime { namespace functions {
             arguments.reserve(2);
             for (auto const& kvp : argument) {
                 arguments.clear();
-                if (_context.lambda().parameter_count() == 1) {
+                if (_context.lambda_parameter_count() == 1) {
                     arguments.emplace_back(values::array { kvp.first, kvp.second });
                 } else {
                     arguments.push_back(kvp.first);
                     arguments.push_back(kvp.second);
                 }
-                _context.lambda().execute(arguments);
+                _context.yield(arguments);
             }
         }
 
@@ -95,13 +95,13 @@ namespace puppet { namespace runtime { namespace functions {
             arguments.reserve(2);
             range.each([&](int64_t index, int64_t value) {
                 arguments.clear();
-                if (_context.lambda().parameter_count() == 1) {
+                if (_context.lambda_parameter_count() == 1) {
                     arguments.push_back(value);
                 } else {
                     arguments.push_back(index);
                     arguments.push_back(value);
                 }
-                _context.lambda().execute(arguments);
+                _context.yield(arguments);
                 return true;
             });
         }
@@ -123,9 +123,9 @@ namespace puppet { namespace runtime { namespace functions {
         if (!context.lambda_given()) {
             throw evaluator.create_exception(context.position(), "expected a lambda to 'each' function but one was not given.");
         }
-        auto count = context.lambda().parameter_count();
+        auto count = context.lambda_parameter_count();
         if (count == 0 || count > 2) {
-            throw evaluator.create_exception(context.lambda().position(), (boost::format("expected 1 or 2 lambda parameters but %1% were given.") % count).str());
+            throw evaluator.create_exception(context.lambda_position(), (boost::format("expected 1 or 2 lambda parameters but %1% were given.") % count).str());
         }
 
         // Visit the argument and return it

--- a/lib/src/runtime/functions/filter.cc
+++ b/lib/src/runtime/functions/filter.cc
@@ -25,13 +25,13 @@ namespace puppet { namespace runtime { namespace functions {
                 arguments.clear();
 
                 string value(1, argument[i]);
-                if (_context.lambda().parameter_count() == 1) {
+                if (_context.lambda_parameter_count() == 1) {
                     arguments.push_back(value);
                 } else {
                     arguments.push_back(static_cast<int64_t>(i));
                     arguments.push_back(value);
                 }
-                if (is_true(_context.lambda().execute(arguments))) {
+                if (is_true(_context.yield(arguments))) {
                     result.emplace_back(rvalue_cast(value));
                 }
             }
@@ -54,13 +54,13 @@ namespace puppet { namespace runtime { namespace functions {
             arguments.reserve(2);
             for (size_t i = 0; i < argument.size(); ++i) {
                 arguments.clear();
-                if (_context.lambda().parameter_count() == 1) {
+                if (_context.lambda_parameter_count() == 1) {
                     arguments.push_back(argument[i]);
                 } else {
                     arguments.push_back(static_cast<int64_t>(i));
                     arguments.push_back(argument[i]);
                 }
-                if (is_true(_context.lambda().execute(arguments))) {
+                if (is_true(_context.yield(arguments))) {
                     result.emplace_back(rvalue_cast(argument[i]));
                 }
             }
@@ -75,13 +75,13 @@ namespace puppet { namespace runtime { namespace functions {
             arguments.reserve(2);
             for (auto& kvp : argument) {
                 arguments.clear();
-                if (_context.lambda().parameter_count() == 1) {
+                if (_context.lambda_parameter_count() == 1) {
                     arguments.emplace_back(values::array { kvp.first, kvp.second });
                 } else {
                     arguments.push_back(kvp.first);
                     arguments.push_back(kvp.second);
                 }
-                if (is_true(_context.lambda().execute(arguments))) {
+                if (is_true(_context.yield(arguments))) {
                     result.emplace(make_pair(kvp.first, rvalue_cast(kvp.second)));
                 }
             }
@@ -117,13 +117,13 @@ namespace puppet { namespace runtime { namespace functions {
 
             range.each([&](int64_t index, int64_t value) {
                 arguments.clear();
-                if (_context.lambda().parameter_count() == 1) {
+                if (_context.lambda_parameter_count() == 1) {
                     arguments.push_back(value);
                 } else {
                     arguments.push_back(index);
                     arguments.push_back(value);
                 }
-                if (is_true(_context.lambda().execute(arguments))) {
+                if (is_true(_context.yield(arguments))) {
                     result.emplace_back(value);
                 }
                 return true;
@@ -148,9 +148,9 @@ namespace puppet { namespace runtime { namespace functions {
         if (!context.lambda_given()) {
             throw evaluator.create_exception(context.position(), "expected a lambda to 'filter' function but one was not given.");
         }
-        auto count = context.lambda().parameter_count();
+        auto count = context.lambda_parameter_count();
         if (count == 0 || count > 2) {
-            throw evaluator.create_exception(context.lambda().position(), (boost::format("expected 1 or 2 lambda parameters but %1% were given.") % count).str());
+            throw evaluator.create_exception(context.lambda_position(), (boost::format("expected 1 or 2 lambda parameters but %1% were given.") % count).str());
         }
 
         value argument = mutate(arguments[0]);

--- a/lib/src/runtime/functions/logging.cc
+++ b/lib/src/runtime/functions/logging.cc
@@ -19,9 +19,9 @@ namespace puppet { namespace runtime { namespace functions {
         string message = ss.str();
 
         auto& evaluator = context.evaluator();
-        auto& logger = evaluator.logger();
+        auto& logger = evaluator.compilation_context()->logger();
         if (logger.would_log(_level)) {
-            logger.log(_level, "%1%: %2%", *evaluator.context().current_scope(), message);
+            logger.log(_level, "%1%: %2%", *evaluator.evaluation_context().current_scope(), message);
         }
         return message;
     }

--- a/lib/src/runtime/functions/with.cc
+++ b/lib/src/runtime/functions/with.cc
@@ -8,9 +8,11 @@ namespace puppet { namespace runtime { namespace functions {
 
     value with::operator()(call_context& context) const
     {
-        return context.lambda().execute(context.arguments(), [&](size_t index, string message) {
-            return context.evaluator().create_exception(context.position(index), rvalue_cast(message));
-        });
+        try {
+            return context.yield_without_catch(context.arguments());
+        } catch (argument_exception const& ex) {
+            throw context.evaluator().create_exception(context.position(ex.index()), ex.what());
+        }
     }
 
 }}}  // namespace puppet::runtime::functions

--- a/lib/src/runtime/operators/assignment.cc
+++ b/lib/src/runtime/operators/assignment.cc
@@ -35,7 +35,7 @@ namespace puppet { namespace runtime { namespace operators {
         }
 
         // Assign the existing value
-        auto previous = evaluator.context().current_scope()->set(var->name(), rvalue_cast(value), evaluator.path(), context.left_position().line());
+        auto previous = evaluator.evaluation_context().current_scope()->set(var->name(), rvalue_cast(value), evaluator.compilation_context()->path(), context.left_position().line());
         if (previous) {
             if (previous->path() && !previous->path()->empty()) {
                 throw evaluator.create_exception(context.left_position(), (boost::format("cannot assign to $%1%: variable was previously assigned at %2%:%3%.") % var->name() % *previous->path() % previous->line()).str());

--- a/lib/src/runtime/operators/in.cc
+++ b/lib/src/runtime/operators/in.cc
@@ -23,7 +23,7 @@ namespace puppet { namespace runtime { namespace operators {
         {
             smatch matches;
             bool result = left.pattern().empty() || regex_search(right, matches, left.value());
-            _context.evaluator().context().set(matches);
+            _context.evaluator().evaluation_context().set(matches);
             return result;
         }
 

--- a/lib/src/runtime/operators/match.cc
+++ b/lib/src/runtime/operators/match.cc
@@ -21,7 +21,7 @@ namespace puppet { namespace runtime { namespace operators {
             try {
                 smatch matches;
                 bool result = right.empty() || regex_search(left, matches, std::regex(right));
-                evaluator.context().set(matches);
+                evaluator.evaluation_context().set(matches);
                 return result;
             } catch (regex_error const& ex) {
                 throw evaluator.create_exception(_context.right_position(), (boost::format("invalid regular expression: %1%") % ex.what()).str());
@@ -32,7 +32,7 @@ namespace puppet { namespace runtime { namespace operators {
         {
             smatch matches;
             bool result = right.pattern().empty() || regex_search(left, matches, right.value());
-            _context.evaluator().context().set(matches);
+            _context.evaluator().evaluation_context().set(matches);
             return result;
         }
 

--- a/lib/src/runtime/operators/relationship.cc
+++ b/lib/src/runtime/operators/relationship.cc
@@ -10,7 +10,7 @@ namespace puppet { namespace runtime { namespace operators {
     static value add_relationship(binary_context& context, string const& attribute_name)
     {
         auto& evaluator = context.evaluator();
-        auto catalog = evaluator.context().catalog();
+        auto catalog = evaluator.evaluation_context().catalog();
         if (!catalog) {
             throw evaluator.create_exception(context.left_position(), "relationship expressions are not supported.");
         }

--- a/lib/src/runtime/string_interpolator.cc
+++ b/lib/src/runtime/string_interpolator.cc
@@ -39,7 +39,7 @@ namespace puppet { namespace runtime {
         lexer_string_iterator const& end,
         function<lexer::position(lexer::position const&)> const& calculate_position)
     {
-        auto& context = evaluator.context();
+        auto& context = evaluator.evaluation_context();
 
         try {
             bool bracket = begin != end && *begin == '{';


### PR DESCRIPTION
`lamda_body` -> `lambda_body`, with a `b`.
 Too bad spell check doesn't work on source code.