### PR TITLE
Implement access operator on fully qualified resource and class types.

### DIFF
--- a/lib/include/puppet/runtime/evaluators/access.hpp
+++ b/lib/include/puppet/runtime/evaluators/access.hpp
@@ -55,6 +55,8 @@ namespace puppet { namespace runtime { namespace evaluators {
 
         void add_resource_reference(values::array& result, std::string const& type_name, values::value& argument, lexer::position const& position);
         void add_class_reference(values::array& result, values::value& argument, lexer::position const& position);
+        values::value access_resource(types::resource const& type);
+        values::value access_attribute(runtime::resource const& resource, size_t index);
 
         template <typename T>
         result_type operator()(T const& target)


### PR DESCRIPTION
The expression `Foo['bar']['baz']` should return the value of attribute `baz`
on resource `Foo[bar]`.  This implements the support in the access evaluator.