### PR TITLE
Fix resources with empty bodies not inheriting default attributes.

### DIFF
--- a/lib/src/runtime/evaluators/catalog.cc
+++ b/lib/src/runtime/evaluators/catalog.cc
@@ -280,6 +280,8 @@ namespace puppet { namespace runtime { namespace evaluators {
                 // Set the attribute
                 attributes->set(attribute.name().value(), evaluate_attribute(attribute));
             }
+        } else if (parent) {
+            attributes = make_shared<runtime::attributes>(rvalue_cast(parent));
         }
         return attributes;
     }


### PR DESCRIPTION
The following code should print 'foo':

```
file {
  default:
  owner => foo
  ;
  '/foo':
  ;
}

notice File['/foo'][owner]
```

However, it results in an error saying that owner is not a parameter on
`File['/foo']` (this itself is a bug, but it cannot be fixed until custom types
are supported).

This fixes the parent pointer of the attributes collection being set when no
attributes are present in a resource body.