### PR TITLE
(Functions) First stab at shellquote function

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -71,6 +71,7 @@ set(PUPPET_COMMON_SOURCES
     src/runtime/functions/filter.cc
     src/runtime/functions/logging.cc
     src/runtime/functions/realize.cc
+    src/runtime/functions/shellquote.cc
     src/runtime/functions/split.cc
     src/runtime/functions/versioncmp.cc
     src/runtime/functions/with.cc

--- a/lib/include/puppet/runtime/functions/shellquote.hpp
+++ b/lib/include/puppet/runtime/functions/shellquote.hpp
@@ -21,7 +21,7 @@ namespace puppet { namespace runtime { namespace functions {
         values::value operator()(call_context& context) const;
 
         private:
-            size_t _count_chars(const std::string &word, const std::string &set) const;
+            std::string _quotify(const values::array& arguments, expression_evaluator& evaluator, call_context& context) const;
     };
 
 }}}  // puppet::runtime::functions

--- a/lib/include/puppet/runtime/functions/shellquote.hpp
+++ b/lib/include/puppet/runtime/functions/shellquote.hpp
@@ -1,0 +1,27 @@
+/**
+ * @file
+ * Declares the shellquote function.
+ */
+#pragma once
+
+#include "../call_context.hpp"
+
+namespace puppet { namespace runtime { namespace functions {
+
+    /**
+     * Implements the shellquote function.
+     */
+    struct shellquote
+    {
+        /**
+         * Called to invoke the function.
+         * @param context The function call context.
+         * @return Returns the resulting value.
+         */
+        values::value operator()(call_context& context) const;
+
+        private:
+            size_t _count_chars(const std::string &word, const std::string &set) const;
+    };
+
+}}}  // puppet::runtime::functions

--- a/lib/src/runtime/dispatcher.cc
+++ b/lib/src/runtime/dispatcher.cc
@@ -9,6 +9,7 @@
 #include <puppet/runtime/functions/split.hpp>
 #include <puppet/runtime/functions/versioncmp.hpp>
 #include <puppet/runtime/functions/with.hpp>
+#include <puppet/runtime/functions/shellquote.hpp>
 #include <puppet/cast.hpp>
 #include <boost/format.hpp>
 
@@ -185,6 +186,7 @@ namespace puppet { namespace runtime {
             { "notice",         functions::logging_function(logging::level::notice) },
             { "realize",        functions::realize() },
             { "require",        functions::declare(relationship::require) },
+            { "shellquote",     functions::shellquote() },
             { "split",          functions::split() },
             { "versioncmp",     functions::versioncmp() },
             { "warning",        functions::logging_function(logging::level::warning) },

--- a/lib/src/runtime/functions/shellquote.cc
+++ b/lib/src/runtime/functions/shellquote.cc
@@ -1,0 +1,78 @@
+#include <puppet/runtime/functions/shellquote.hpp>
+
+
+using namespace std;
+using namespace puppet::lexer;
+using namespace puppet::runtime::values;
+
+namespace puppet { namespace runtime { namespace functions {
+    // FIXME: How should this handle unicode? The original ruby only handles
+    // the printable ascii range.
+
+    // Faithfully translated from the original lib/puppet/parser/functions/shellquote.rb
+    /** Quote and concatenate arguments for use in Bourne shell.
+
+     Each argument is quoted separately, and then all are concatenated
+     with spaces.  If an argument is an array, each element of that
+     array is interpolated within the rest of the arguments; this makes
+     it possible to have an array of arguments and pass that array to
+     shellquote instead of having to specify each argument
+     individually in the call.
+    */
+    value shellquote::operator()(call_context& context) const
+    {
+        // EWWWW!!
+        const string safe = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0-9@%_+=:,./-";
+        const string dangerous =  "!\"`$\\";
+        auto& evaluator = context.evaluator();
+        vector<const string> result;
+
+        auto& arguments = context.arguments();
+        for (size_t i = 0; i < arguments.size(); ++i) {
+            auto word = as<string>(arguments[i]);
+            if (!word) {
+                throw evaluator.create_exception(context.position(i), (boost::format("expected %1% for first argument but found %2%.") % types::string::name() % get_type(arguments[i])).str());
+            }
+            if (word->length() != 0 && _count_chars(*word, safe) == word->length()) {
+                result.push_back(*word);
+            } else if (_count_chars(*word, dangerous) == 0) {
+                result.push_back((boost::format("\"%1%\"") % *word).str());
+            } else if (_count_chars(*word, "'") == 0) {
+                result.push_back((boost::format("'%1%'") % *word).str());
+            } else {
+                string r = "\"";
+                for (auto &c : *word) {
+                    if (dangerous.find(c) != string::npos) {
+                        r += "\\";
+                    }
+                    r += c;
+                }
+                r += "\"";
+                result.push_back(r);
+            }
+        }
+        // There's probably a better way to do this too.
+        string ret;
+        for (auto &str : result) {
+            ret += str;
+            ret += " ";
+        }
+        return ret;
+    }
+
+    // O(N*M) :( Is there some sort of cheap hash function which
+    // Also, there's probably functional C++11 wizardry which could make this
+    // a 1 liner.
+    size_t shellquote::_count_chars(const string &word, const string &set) const {
+        int count = 0;
+        for (auto const &chr : word) {
+            for (auto const &elem : set) {
+                if (chr == elem) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+}}}  // namespace puppet::runtime::functions


### PR DESCRIPTION
You can just smell the ruby coming off this function. There's other weirdness too but it works out of the box:
```
iankronquist@puppettop:(ttest) → cat shellquote/bar.pp 
$a = 'rm -rf *'
$b = '$(boot2docker shellinit)'
$c = "alias jcheck=\"python -c 'import json; import sys; print(json.load(open(sys.argv[1])))'\""
$d = "!'\"$`"
notice shellquote($a)
notice shellquote($b)
notice shellquote($c)
notice shellquote($d)
iankronquist@puppettop:(ttest) → ~/gg/puppetcpp/debug/bin/puppetcpp shellquote/bar.pp 
Notice: compiling for node 'puppettop.delivery.puppetlabs.net' with environment 'production'.
Notice: Scope(Class[main]): "rm -rf *" 
Notice: Scope(Class[main]): '$(boot2docker shellinit)' 
Notice: Scope(Class[main]): "alias jcheck=\"python -c 'import json; import sys; print(json.load(open(sys.argv[1])))'\"" 
Notice: Scope(Class[main]): "\!'\"\$\`" 
Notice: compilation succeeded with 0 errors and 0 warnings.
```