### PR TITLE
Replace Tiernan with Hawick circuits algorithm.

### DIFF
--- a/exe/main.cc
+++ b/exe/main.cc
@@ -79,11 +79,10 @@ int main(int argc, char const* argv[])
     } catch (yaml_parse_exception const& ex) {
         LOG(error, ex.line(), ex.column(), ex.text(), ex.path(), ex.what());
     } catch (compiler::settings_exception const& ex) {
-        LOG(error, "%1%", ex.what());
+        LOG(error, ex.what());
         LOG(notice, "use 'puppetcpp --help' for help.");
         return EXIT_FAILURE;
-    }
-    catch (exception const& ex) {
+    } catch (exception const& ex) {
         LOG(critical, "unhandled exception: %1%", ex.what());
     }
 

--- a/lib/include/puppet/runtime/catalog.hpp
+++ b/lib/include/puppet/runtime/catalog.hpp
@@ -714,7 +714,7 @@ namespace puppet { namespace runtime {
 
         /**
          * Detects cycles within the graph.
-         * Throws an evaluation exception if cycles are detected.
+         * Throws a compilation_exception if cycles are detected.
          */
         void detect_cycles();
 
@@ -737,7 +737,7 @@ namespace puppet { namespace runtime {
         // Stores the mapping between defined type name (e.g. foo::bar) and the defined type definition
         std::unordered_map<std::string, defined_type> _defined_type_definitions;
         // Stores the declared defined types in declaration order
-        std::deque<std::pair<defined_type const*, resource*>> _defined_types;
+        std::vector<std::pair<defined_type const*, resource*>> _defined_types;
         // Stores the node definitions in declaration order
         std::vector<node_definition> _node_definitions;
         // Stores the mapping between a node name and the index into the node definitions list

--- a/lib/src/runtime/catalog.cc
+++ b/lib/src/runtime/catalog.cc
@@ -3,7 +3,7 @@
 #include <puppet/runtime/executor.hpp>
 #include <puppet/compiler/node.hpp>
 #include <puppet/ast/expression_def.hpp>
-#include <boost/graph/tiernan_all_cycles.hpp>
+#include <boost/graph/hawick_circuits.hpp>
 #include <boost/graph/graphviz.hpp>
 #include <boost/format.hpp>
 #include <rapidjson/document.h>
@@ -1333,7 +1333,7 @@ namespace puppet { namespace runtime {
     {
         // Check for cycles in the graph
         vector<string> cycles;
-        boost::tiernan_all_cycles(_graph, cycle_visitor(cycles));
+        boost::hawick_unique_circuits(_graph, cycle_visitor(cycles));
         if (cycles.empty()) {
             return;
         }
@@ -1347,7 +1347,7 @@ namespace puppet { namespace runtime {
             }
             message << "  " << i + 1 << ". " << cycles[i];
         }
-        throw evaluation_exception(message.str());
+        throw compiler::compilation_exception(message.str());
     }
 
     void catalog::populate_graph()


### PR DESCRIPTION
Dependency cycle detection was using the Tiernan algorithm for finding cycles
in the graph.  Tiernan doesn't scale for large resource sets, so this
commit replaces its usage with the Hawick circuits algorithm.

This also fixes an incorrect error message when cycles are detected.