### PR TITLE
Build fixes for Linux.

### DIFF
--- a/lib/include/puppet/facts/facter.hpp
+++ b/lib/include/puppet/facts/facter.hpp
@@ -7,16 +7,7 @@
 #include "provider.hpp"
 #include "../logging/logger.hpp"
 #include <unordered_map>
-
-namespace facter { namespace facts {
-
-    // Forward declaration of collection
-    struct collection;
-
-    // Forward declaration of value
-    struct value;
-
-}}  // namespace facter::facts
+#include <facter/facts/collection.hpp>
 
 namespace puppet { namespace facts {
 

--- a/lib/src/runtime/functions/versioncmp.cc
+++ b/lib/src/runtime/functions/versioncmp.cc
@@ -44,22 +44,22 @@ namespace puppet { namespace runtime { namespace functions {
             } else if (a == "-" && b == "-") {
                 continue;
             } else if (a == "-") {
-                return -1ll;
+                return static_cast<int64_t>(-1);
             } else if (b == "-") {
-                return 1ll;
+                return static_cast<int64_t>(1);
             } else if (a == "." && b == ".") {
                 continue;
             } else if (a == ".") {
-                return -1ll;
+                return static_cast<int64_t>(-1);
             } else if (b == ".") {
-                return 1ll;
+                return static_cast<int64_t>(1);
             } else if (regex_match(a, digit_regex) &&
                        regex_match(b, digit_regex) &&
                        a[0] != '0' &&
                        b[0] != '0') {
                 return static_cast<int64_t>(stoi(a) - stoi(b));
             } else {
-                return boost::ilexicographical_compare(a, b) ? -1ll : 1ll;
+                return static_cast<int64_t>(boost::ilexicographical_compare(a, b) ? -1 : 1);
             }
         }
         return static_cast<int64_t>(version_a->compare(*version_b));


### PR DESCRIPTION
Fixing the build for Linux builds with GCC.

The facter header file failed to include facter's collection header so
it was not building (not caught because of cached PCH on a different
platform).

GCC has issues with the implicit casts of long long to value.  Adding
some static casts to make the cast to int64_t explicit, which allows the
implicit cast to value.