### PR TITLE
Delay adding virtual resources to the dependency graph.

### DIFF
--- a/lib/include/puppet/runtime/collectors/collector.hpp
+++ b/lib/include/puppet/runtime/collectors/collector.hpp
@@ -62,10 +62,11 @@ namespace puppet { namespace runtime { namespace collectors {
      protected:
         /**
          * Collects the given resource.
+         * @param catalog The current catalog.
          * @param resource The resource to collect.
          * @param check True to check if the resource is already in the list or false to always add the resource.
          */
-        void collect_resource(runtime::resource* resource, bool check = true);
+        void collect_resource(runtime::catalog& catalog, runtime::resource& resource, bool check = true);
 
      private:
         std::vector<resource*> _resources;

--- a/lib/src/runtime/collectors/collector.cc
+++ b/lib/src/runtime/collectors/collector.cc
@@ -19,25 +19,21 @@ namespace puppet { namespace runtime { namespace collectors {
         _attributes = rvalue_cast(attributes);
     }
 
-    void collector::collect_resource(runtime::resource* resource, bool check)
+    void collector::collect_resource(runtime::catalog& catalog, runtime::resource& resource, bool check)
     {
-        if (!resource) {
-            return;
-        }
-
         // Realize the resource
-        resource->realize();
+        catalog.realize(resource);
 
         // Override any attributes
-        resource->set(_attributes, true);
+        resource.set(_attributes, true);
 
         // Check if the resource is already in the list
-        if (check && find(_resources.begin(), _resources.end(), resource) != _resources.end()) {
+        if (check && find(_resources.begin(), _resources.end(), &resource) != _resources.end()) {
             return;
         }
 
         // Add to the list
-        _resources.push_back(resource);
+        _resources.push_back(&resource);
     }
 
 }}}  // namespace puppet::runtime::collectors

--- a/lib/src/runtime/collectors/list_collector.cc
+++ b/lib/src/runtime/collectors/list_collector.cc
@@ -44,7 +44,7 @@ namespace puppet { namespace runtime { namespace collectors {
             }
 
             // Collect the resource
-            collect_resource(resource);
+            collect_resource(*catalog, *resource);
 
             // Remove from the list
             _list.erase(it++);

--- a/lib/src/runtime/collectors/query_collector.cc
+++ b/lib/src/runtime/collectors/query_collector.cc
@@ -50,7 +50,7 @@ namespace puppet { namespace runtime { namespace collectors {
             }
 
             // Collect the resource
-            collect_resource(resource, false);
+            collect_resource(*catalog, *resource, false);
         }
     }
 


### PR DESCRIPTION
Virtual resources should not be added to the dependency graph until they are
realized.  This change delays adding a vertex to the graph until the resource
is realized.