### PR TITLE
Limit default manifest files by .pp extension.

### DIFF
--- a/lib/src/compiler/environment.cc
+++ b/lib/src/compiler/environment.cc
@@ -57,7 +57,7 @@ namespace puppet { namespace compiler {
 
         // Add all files to the
         for (; it != end; ++it) {
-            if (fs::is_regular_file(it->status())) {
+            if (fs::is_regular_file(it->status()) && it->path().extension() == ".pp") {
                 paths.emplace_back(it->path().string());
             }
         }


### PR DESCRIPTION
Currently the compiler is attempting to parse any files in the environment's
manifests directory.  This change limits the parsing to only .pp files.