### PR TITLE
Fix filter and each methods not properly enumerating Unicode strings.

### DIFF
--- a/lib/include/puppet/runtime/values/value.hpp
+++ b/lib/include/puppet/runtime/values/value.hpp
@@ -414,4 +414,11 @@ namespace puppet { namespace runtime { namespace values {
      */
     rapidjson::Value to_json(values::value const* value, rapidjson::Allocator& allocator);
 
+    /**
+     * Enumerates each Unicode code point in the given string.
+     * @param str The string to enumerate.
+     * @param callback The callback to call for each Unicode code point, passed as a UTF-8 string.
+     */
+    void enumerate_string(std::string const& str, std::function<bool(std::string)> const& callback);
+
 }}}  // namespace puppet::runtime::values

--- a/lib/src/runtime/functions/each.cc
+++ b/lib/src/runtime/functions/each.cc
@@ -18,16 +18,20 @@ namespace puppet { namespace runtime { namespace functions {
         {
             values::array arguments;
             arguments.reserve(2);
-            for (size_t i = 0; i < argument.size(); ++i) {
+
+            // Enumerate the string as Unicode codepoints
+            int64_t i = 0;
+            enumerate_string(argument, [&](string codepoint) {
                 arguments.clear();
                 if (_context.lambda_parameter_count() == 1) {
-                    arguments.push_back(string(1, argument[i]));
+                    arguments.push_back(rvalue_cast(codepoint));
                 } else {
-                    arguments.push_back(static_cast<int64_t>(i));
-                    arguments.push_back(string(1, argument[i]));
+                    arguments.push_back(i++);
+                    arguments.push_back(rvalue_cast(codepoint));
                 }
                 _context.yield(arguments);
-            }
+                return true;
+            });
         }
 
         result_type operator()(int64_t argument) const

--- a/lib/src/runtime/functions/filter.cc
+++ b/lib/src/runtime/functions/filter.cc
@@ -21,20 +21,22 @@ namespace puppet { namespace runtime { namespace functions {
 
             values::array arguments;
             arguments.reserve(2);
-            for (size_t i = 0; i < argument.size(); ++i) {
-                arguments.clear();
 
-                string value(1, argument[i]);
+            // Enumerate the string as Unicode codepoints
+            int64_t i = 0;
+            enumerate_string(argument, [&](string codepoint) {
+                arguments.clear();
                 if (_context.lambda_parameter_count() == 1) {
-                    arguments.push_back(value);
+                    arguments.push_back(codepoint);
                 } else {
-                    arguments.push_back(static_cast<int64_t>(i));
-                    arguments.push_back(value);
+                    arguments.push_back(i++);
+                    arguments.push_back(codepoint);
                 }
                 if (is_true(_context.yield(arguments))) {
-                    result.emplace_back(rvalue_cast(value));
+                    result.emplace_back(rvalue_cast(codepoint));
                 }
-            }
+                return true;
+            });
             return result;
         }
 

--- a/lib/src/runtime/values/value.cc
+++ b/lib/src/runtime/values/value.cc
@@ -5,6 +5,7 @@
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <rapidjson/document.h>
+#include <utf8.h>
 
 using namespace std;
 using namespace rapidjson;
@@ -471,6 +472,19 @@ namespace puppet { namespace runtime { namespace values {
     rapidjson::Value to_json(values::value const& value, Allocator& allocator)
     {
         return boost::apply_visitor(json_visitor(allocator), value);
+    }
+
+    void enumerate_string(string const& str, function<bool(string)> const& callback)
+    {
+        // Go through each Unicode code point in the string
+        auto current = str.begin();
+        while (current != str.end()) {
+            auto begin = current;
+            utf8::next(current, str.end());
+            if (!callback(string(begin, current))) {
+                break;
+            }
+        }
     }
 
 }}}  // namespace puppet::runtime::values


### PR DESCRIPTION
The filter and each methods were enumerating string arguments by bytes rather
than Unicode code points.  This fixes the functions to properly enumerate the
individual code points instead of the bytes.