### PR TITLE
Implement the NotUndef type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ Puppet Compiler in C++
 
 [![Build Status](https://travis-ci.org/peterhuene/puppetcpp.svg?branch=master)](https://travis-ci.org/peterhuene/puppetcpp)
 
-This is a (very early) attempt to write a Puppet 4 compiler in C++14.
+This is a (very early) attempt to write a Puppet 4.x compiler in C++14.
 
 Parser status:
 
-* [x] Puppet 4 compliant lexer
-* [x] Puppet 4 compliant parser
+* [x] Puppet 4.x compliant lexer
+* [x] Puppet 4.x compliant parser
 * [x] AST construction
 
 Expression evaluator status:
@@ -83,6 +83,7 @@ Type system implemented:
 * [x] Hash
 * [x] Integer
 * [x] Class
+* [x] NotUndef
 * [x] Numeric
 * [x] Optional
 * [x] Pattern

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -98,6 +98,7 @@ set(PUPPET_COMMON_SOURCES
     src/runtime/types/floating.cc
     src/runtime/types/hash.cc
     src/runtime/types/integer.cc
+    src/runtime/types/not_undef.cc
     src/runtime/types/numeric.cc
     src/runtime/types/optional.cc
     src/runtime/types/pattern.cc

--- a/lib/include/puppet/runtime/types/not_undef.hpp
+++ b/lib/include/puppet/runtime/types/not_undef.hpp
@@ -1,0 +1,110 @@
+/**
+ * @file
+ * Declares the NotUndef type.
+ */
+#pragma once
+
+#include "../values/forward.hpp"
+#include <ostream>
+#include <memory>
+
+namespace puppet { namespace runtime { namespace types {
+
+    /**
+     * Represents the Puppet NotUndef type.
+     */
+    struct not_undef
+    {
+        /**
+         * Constructs an NotUndef type.
+         * @param type The optional type.
+         */
+        explicit not_undef(std::unique_ptr<values::type> type = nullptr);
+
+        /**
+         * Copy constructor for NotUndef type.
+         * @param other The other NotUndef type to copy from.
+         */
+        not_undef(not_undef const& other);
+
+        /**
+         * Move constructor for NotUndef type.
+         * Uses the default implementation.
+         */
+        not_undef(not_undef&&) noexcept = default;
+
+        /**
+         * Copy assignment operator for NotUndef type.
+         * @param other The other NotUndef type to copy assign from.
+         * @return Returns this NotUndef type.
+         */
+        not_undef& operator=(not_undef const& other);
+
+        /**
+         * Move assignment operator for NotUndef type.
+         * Uses the default implementation.
+         * @return Returns this NotUndef type.
+         */
+        not_undef& operator=(not_undef&&) noexcept = default;
+
+        /**
+         * Gets the optional type.
+         * @return Returns the optional type.
+         */
+        std::unique_ptr<values::type> const& type() const;
+
+        /**
+         * Gets the name of the type.
+         * @return Returns the name of the type (i.e. NotUndef).
+         */
+        static char const* name();
+
+        /**
+         * Determines if the given value is an instance of this type.
+         * @param value The value to determine if it is an instance of this type.
+         * @return Returns true if the given value is an instance of this type or false if not.
+         */
+        bool is_instance(values::value const& value) const;
+
+        /**
+         * Determines if the given type is a specialization (i.e. more specific) of this type.
+         * @param other The other type to check for specialization.
+         * @return Returns true if the other type is a specialization or false if not.
+         */
+        bool is_specialization(values::type const& other) const;
+
+     private:
+        std::unique_ptr<values::type> _type;
+    };
+
+    /**
+     * Stream insertion operator for NotUndef type.
+     * @param os The output stream to write the type to.
+     * @return Returns the given output stream.
+     */
+    std::ostream& operator<<(std::ostream& os, not_undef const& type);
+
+    /**
+     * Equality operator for NotUndef type.
+     * @param left The left type to compare.
+     * @param right The right type to compare.
+     * @return Returns true if the two types are equal or false if not.
+     */
+    bool operator==(not_undef const& left, not_undef const& right);
+
+    /**
+     * Inequality operator for NotUndef type.
+     * @param left The left type to compare.
+     * @param right The right type to compare.
+     * @return Returns true if the two types are not equal or false if they are equal.
+     */
+    bool operator!=(not_undef const& left, not_undef const& right);
+
+    /**
+     * Hashes the NotUndef type.
+     * @param type The NotUndef type to hash.
+     * @return Returns the hash value for the type.
+     */
+    size_t hash_value(not_undef const& type);
+
+}}}  // namespace puppet::runtime::types

--- a/lib/include/puppet/runtime/values/type.hpp
+++ b/lib/include/puppet/runtime/values/type.hpp
@@ -18,6 +18,7 @@
 #include "../types/floating.hpp"
 #include "../types/hash.hpp"
 #include "../types/integer.hpp"
+#include "../types/not_undef.hpp"
 #include "../types/numeric.hpp"
 #include "../types/optional.hpp"
 #include "../types/pattern.hpp"
@@ -63,6 +64,7 @@ namespace puppet { namespace runtime { namespace values {
         types::floating,
         types::hash,
         types::integer,
+        types::not_undef,
         types::numeric,
         types::optional,
         types::pattern,

--- a/lib/src/compiler/evaluation/access_evaluator.cc
+++ b/lib/src/compiler/evaluation/access_evaluator.cc
@@ -383,6 +383,20 @@ namespace puppet { namespace compiler { namespace evaluation {
             return types::optional(make_unique<values::type>(_arguments[0]->move_as<values::type>()));
         }
 
+        value operator()(not_undef const& target)
+        {
+            // Only 1 argument to NotUndef
+            if (_arguments.size() > 1) {
+                throw evaluation_exception((boost::format("expected 1 argument for %1% but %2% were given.") % optional::name() % _arguments.size()).str(), _contexts[2]);
+            }
+
+            // First argument should be a type
+            if (!_arguments[0]->as<values::type>()) {
+                throw evaluation_exception((boost::format("expected parameter to be %1% but found %2%.") % types::type::name() % _arguments[0]->get_type()).str(), _contexts[0]);
+            }
+            return types::not_undef(make_unique<values::type>(_arguments[0]->move_as<values::type>()));
+        }
+
         value operator()(types::type const& target)
         {
             // Only 1 argument to Type

--- a/lib/src/compiler/evaluation/access_evaluator.cc
+++ b/lib/src/compiler/evaluation/access_evaluator.cc
@@ -376,11 +376,23 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception((boost::format("expected 1 argument for %1% but %2% were given.") % optional::name() % _arguments.size()).str(), _contexts[2]);
             }
 
-            // First argument should be a type
-            if (!_arguments[0]->as<values::type>()) {
-                throw evaluation_exception((boost::format("expected parameter to be %1% but found %2%.") % types::type::name() % _arguments[0]->get_type()).str(), _contexts[0]);
+            // Check for type argument
+            if (_arguments[0]->as<values::type>()) {
+                return types::optional(make_unique<values::type>(_arguments[0]->move_as<values::type>()));
             }
-            return types::optional(make_unique<values::type>(_arguments[0]->move_as<values::type>()));
+            // Check for string argument (treat as Optional[Enum[<string>]])
+            if (_arguments[0]->as<std::string>()) {
+                vector<std::string> values;
+                values.emplace_back(_arguments[0]->move_as<std::string>());
+                return types::optional(make_unique<values::type>(types::enumeration(rvalue_cast(values))));
+            }
+            throw evaluation_exception(
+                (boost::format("expected parameter to be %1% or %2% but found %3%.") %
+                 types::type::name() %
+                 types::string::name() %
+                 _arguments[0]->get_type()
+                ).str(),
+                _contexts[0]);
         }
 
         value operator()(not_undef const& target)
@@ -390,11 +402,23 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception((boost::format("expected 1 argument for %1% but %2% were given.") % optional::name() % _arguments.size()).str(), _contexts[2]);
             }
 
-            // First argument should be a type
-            if (!_arguments[0]->as<values::type>()) {
-                throw evaluation_exception((boost::format("expected parameter to be %1% but found %2%.") % types::type::name() % _arguments[0]->get_type()).str(), _contexts[0]);
+            // Check for type argument
+            if (_arguments[0]->as<values::type>()) {
+                return types::not_undef(make_unique<values::type>(_arguments[0]->move_as<values::type>()));
             }
-            return types::not_undef(make_unique<values::type>(_arguments[0]->move_as<values::type>()));
+            // Check for string argument (treat as Optional[Enum[<string>]])
+            if (_arguments[0]->as<std::string>()) {
+                vector<std::string> values;
+                values.emplace_back(_arguments[0]->move_as<std::string>());
+                return types::not_undef(make_unique<values::type>(types::enumeration(rvalue_cast(values))));
+            }
+            throw evaluation_exception(
+                (boost::format("expected parameter to be %1% or %2% but found %3%.") %
+                 types::type::name() %
+                 types::string::name() %
+                 _arguments[0]->get_type()
+                ).str(),
+                _contexts[0]);
         }
 
         value operator()(types::type const& target)

--- a/lib/src/compiler/evaluation/evaluator.cc
+++ b/lib/src/compiler/evaluation/evaluator.cc
@@ -179,6 +179,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             { types::hash::name(),          types::hash() },
             { types::integer::name(),       types::integer() },
             { types::klass::name(),         types::klass() },
+            { types::not_undef::name(),     types::not_undef() },
             { types::numeric::name(),       types::numeric() },
             { types::optional::name(),      types::optional() },
             { types::pattern::name(),       types::pattern() },

--- a/lib/src/runtime/types/not_undef.cc
+++ b/lib/src/runtime/types/not_undef.cc
@@ -1,0 +1,101 @@
+#include <puppet/runtime/values/value.hpp>
+#include <puppet/cast.hpp>
+#include <boost/functional/hash.hpp>
+
+using namespace std;
+
+namespace puppet { namespace runtime { namespace types {
+
+    not_undef::not_undef(unique_ptr<values::type> type) :
+        _type(rvalue_cast(type))
+    {
+    }
+
+    not_undef::not_undef(not_undef const& other) :
+        _type(other.type() ? new values::type(*other.type()) : nullptr)
+    {
+    }
+
+    not_undef& not_undef::operator=(not_undef const& other)
+    {
+        _type.reset(other.type() ? new values::type(*other.type()) : nullptr);
+        return *this;
+    }
+
+    unique_ptr<values::type> const& not_undef::type() const
+    {
+        return _type;
+    }
+
+    char const* not_undef::name()
+    {
+        return "NotUndef";
+    }
+
+    bool not_undef::is_instance(values::value const& value) const
+    {
+        // Undef never matches
+        if (value.is_undef()) {
+            return false;
+        }
+
+        // Unparameterized means "anything that isn't undef"
+        if (!_type) {
+            return true;
+        }
+
+        // Check that the instance is of the given type
+        return _type->is_instance(value);
+    }
+
+    bool not_undef::is_specialization(values::type const& other) const
+    {
+        // If this type has a specialization, the other type cannot be a specialization
+        if (_type) {
+            return false;
+        }
+        // Check that the other type is specialized
+        auto not_undef = boost::get<types::not_undef>(&other);
+        return not_undef && not_undef->type();
+    }
+
+    ostream& operator<<(ostream& os, not_undef const& type)
+    {
+        os << not_undef::name();
+        if (!type.type()) {
+            return os;
+        }
+        os << '[' << *type.type() << ']';
+        return os;
+    }
+
+    bool operator==(not_undef const& left, not_undef const& right)
+    {
+        if (!left.type() && !right.type()) {
+            return true;
+        } else if (!left.type()) {
+            return false;
+        } else if (!right.type()) {
+            return false;
+        }
+        return *left.type() == *right.type();
+    }
+
+    bool operator!=(not_undef const& left, not_undef const& right)
+    {
+        return !(left == right);
+    }
+
+    size_t hash_value(not_undef const& type)
+    {
+        static const size_t name_hash = boost::hash_value(not_undef::name());
+
+        size_t seed = 0;
+        boost::hash_combine(seed, name_hash);
+        if (type.type()) {
+            boost::hash_combine(seed, *type.type());
+        }
+        return seed;
+    }
+
+}}}  // namespace puppet::runtime::types


### PR DESCRIPTION
Implementing the Puppet `NotUndef` type.

Implement `NotUndef[string]` and `Optional[string]` expressions.

This fixes GitHub issues #25 and #83.