### PR TITLE
Fix parser rule for resource expression.

### DIFF
--- a/lib/include/puppet/compiler/parser/rules.hpp
+++ b/lib/include/puppet/compiler/parser/rules.hpp
@@ -287,7 +287,7 @@ namespace puppet { namespace compiler { namespace parser {
     DEFINE_RULE(
         resource_type,
         ((name | class_name) > boost::spirit::x3::attr(std::vector<ast::postfix_subexpression>())) |
-        type_expression
+        (type >> +access_expression)
     )
     DEFINE_RULE(
         class_name,

--- a/lib/src/compiler/evaluation/functions/inline_epp.cc
+++ b/lib/src/compiler/evaluation/functions/inline_epp.cc
@@ -49,7 +49,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         try {
             // Parse the string as an EPP template
             auto tree = parser::parse_string(*input, path, nullptr, true);
-            LOG(debug, "parsed inline EPP AST:\n-----%1%\n-----", *tree);
+            LOG(debug, "parsed inline EPP AST:\n-----\n%1%\n-----", *tree);
 
             // Create a local EPP stream
             ostringstream os;


### PR DESCRIPTION
The resource expression rule was greedily matching against a type without a
access expression, causing a failure when the parser encountered a resource
defaults expression.

The fix is to change the rule to require the type to have at least one access
expression to match the resource expression rule.  This allows the rule to
gracefully fail to parse and allow the resource defaults expression rule to
match.

Also a minor fix to the debug output of `inline_epp` (missing new line).