### PR TITLE
Fix assignment of values from `char const*`.

### DIFF
--- a/lib/include/puppet/runtime/values/value.hpp
+++ b/lib/include/puppet/runtime/values/value.hpp
@@ -116,11 +116,29 @@ namespace puppet { namespace runtime { namespace values {
         value(values::wrapper<value>&& wrapper);
 
         /**
+         * Constructs a value given a C string.
+         * @param string The string to construct the value with.
+         */
+        value(char const* string);
+
+        /**
+         * Intentionally undefined constructor to prevent implicit conversion to a boolean value.
+         */
+        value(void const*);
+
+        /**
          * Move assigns the value given a wrapper containing the value to move.
          * @param wrapper The wrapper containing the value to move.
          * @return Returns this value.
          */
         value& operator=(values::wrapper<value>&& wrapper);
+
+        /**
+         * Copy assignment operator given a C-string to set as a string value.
+         * @param string The string to assign to the value.
+         * @return Returns this value.
+         */
+        value& operator=(char const* string);
 
         /**
          * Copy assignment operator for value.

--- a/lib/src/runtime/values/value.cc
+++ b/lib/src/runtime/values/value.cc
@@ -19,9 +19,20 @@ namespace puppet { namespace runtime { namespace values {
     {
     }
 
+    value::value(char const* string) :
+        value_base(std::string(string))
+    {
+    }
+
     value& value::operator=(values::wrapper<value>&& wrapper)
     {
         value_base::operator=(rvalue_cast(static_cast<value_base&>(wrapper.get())));
+        return *this;
+    }
+
+    value& value::operator=(char const* string)
+    {
+        value_base::operator=(std::string(string));
         return *this;
     }
 


### PR DESCRIPTION
Due to value also supporting boolean as a value type, the implicit conversion
from `char const*` to `bool` was being selected over the expected conversion to
`std::string`.

This fixes the unintentional assignment by defining an explicit constructor and
assignment operator for `char const*`.