### PR TITLE
Parser bug fixes

### DIFF
--- a/lib/include/puppet/compiler/evaluation/evaluator.hpp
+++ b/lib/include/puppet/compiler/evaluation/evaluator.hpp
@@ -33,7 +33,7 @@ namespace puppet { namespace compiler { namespace evaluation {
         /**
          * Evaluates all statements in a syntax tree.
          * @param tree The syntax tree to evaluate.
-         * @param arguments The arguments for the tree (EEP syntax trees).
+         * @param arguments The arguments for the tree (EPP syntax trees).
          */
         void evaluate(ast::syntax_tree const& tree, runtime::values::hash* arguments = nullptr);
 

--- a/lib/include/puppet/compiler/parser/parsers.hpp
+++ b/lib/include/puppet/compiler/parser/parsers.hpp
@@ -551,6 +551,32 @@ namespace boost { namespace spirit { namespace x3 {
     };
 
     /**
+     * Responsible for getting the info of a position parser.
+     */
+    template <>
+    struct get_info<puppet::compiler::parser::position>
+    {
+        /**
+         * The parser type.
+         */
+        using parser_type = puppet::compiler::parser::position;
+        /**
+         * The result type.
+         */
+        using result_type = std::string;
+
+        /**
+         * Gets the info for a parser.
+         * @param parser The parser to get the info for.
+         * @return Returns the info for the parser.
+         */
+        result_type operator()(parser_type const& parser) const
+        {
+            return boost::lexical_cast<result_type>(parser.id());
+        }
+    };
+
+    /**
      * Responsible for getting the info of a string token parser.
      */
     template <>


### PR DESCRIPTION
Fixing the following in the parser:

* Error message for missing `}` in string interpolating was incorrect (output parser typeinfo instead of the expected token).
* EPP parsing was not strict on checking for a missing end tag for opening tags `<%` and `<%-`.