### PR TITLE
Switch `long double` to `double`

### DIFF
--- a/lib/include/puppet/compiler/evaluation/evaluator.hpp
+++ b/lib/include/puppet/compiler/evaluation/evaluator.hpp
@@ -76,7 +76,7 @@ namespace puppet { namespace compiler { namespace evaluation {
         runtime::values::value operator()(ast::defaulted const&);
         runtime::values::value operator()(ast::boolean const& expression);
         runtime::values::value operator()(int64_t value);
-        runtime::values::value operator()(long double value);
+        runtime::values::value operator()(double value);
         runtime::values::value operator()(ast::number const& expression);
         runtime::values::value operator()(ast::string const& expression);
         runtime::values::value operator()(ast::regex const& expression);

--- a/lib/include/puppet/compiler/lexer/lexer.hpp
+++ b/lib/include/puppet/compiler/lexer/lexer.hpp
@@ -605,8 +605,8 @@ namespace puppet { namespace compiler { namespace lexer {
                     throw lexer_exception<input_iterator_type>(start,
                         (boost::format("'%1%' is not in the range of %2% to %3%.") %
                             token %
-                            numeric_limits<long double>::min() %
-                            numeric_limits<long double>::max()
+                            numeric_limits<double>::min() %
+                            numeric_limits<double>::max()
                         ).str());
                 }
                 return;

--- a/lib/include/puppet/compiler/lexer/number_token.hpp
+++ b/lib/include/puppet/compiler/lexer/number_token.hpp
@@ -39,7 +39,7 @@ namespace puppet { namespace compiler { namespace lexer {
         /**
          * The type of the numeric value.
          */
-        using value_type = boost::variant<std::int64_t, long double>;
+        using value_type = boost::variant<std::int64_t, double>;
 
         /**
          * The default constructor for number token.
@@ -59,7 +59,7 @@ namespace puppet { namespace compiler { namespace lexer {
          * @param position The position of the token.
          * @param value The floating point value of the token.
          */
-        number_token(lexer::position position, long double value);
+        number_token(lexer::position position, double value);
 
         /**
          * Gets the position of the token.

--- a/lib/include/puppet/runtime/types/floating.hpp
+++ b/lib/include/puppet/runtime/types/floating.hpp
@@ -20,19 +20,19 @@ namespace puppet { namespace runtime { namespace types {
          * @param from The "from" type parameter.
          * @param to The "to" type parameter.
          */
-        explicit floating(long double from = std::numeric_limits<long double>::min(), long double to = std::numeric_limits<long double>::max());
+        explicit floating(double from = std::numeric_limits<double>::min(), double to = std::numeric_limits<double>::max());
 
         /**
          * Gets the "from" type parameter.
          * @return Returns the "from" type parameter.
          */
-        long double from() const;
+        double from() const;
 
         /**
          * Gets the "to" type parameter.
          * @return Returns the "to" type parameter.
          */
-        long double to() const;
+        double to() const;
 
         /**
          * Gets the name of the type.
@@ -55,8 +55,8 @@ namespace puppet { namespace runtime { namespace types {
         bool is_specialization(values::type const& other) const;
 
      private:
-        long double _from;
-        long double _to;
+        double _from;
+        double _to;
     };
 
     /**

--- a/lib/include/puppet/runtime/values/value.hpp
+++ b/lib/include/puppet/runtime/values/value.hpp
@@ -51,7 +51,7 @@ namespace puppet { namespace runtime { namespace values {
         undef,
         defaulted,
         std::int64_t,
-        long double,
+        double,
         bool,
         std::string,
         regex,

--- a/lib/src/compiler/evaluation/access_evaluator.cc
+++ b/lib/src/compiler/evaluation/access_evaluator.cc
@@ -197,8 +197,8 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception((boost::format("expected at most 2 arguments for %1% but %2% were given.") % floating::name() % _arguments.size()).str(), _contexts[2]);
             }
 
-            long double from, to;
-            tie(from, to) = get_range<long double, floating>();
+            double from, to;
+            tie(from, to) = get_range<double, floating>();
             return floating(from, to);
         }
 

--- a/lib/src/compiler/evaluation/evaluator.cc
+++ b/lib/src/compiler/evaluation/evaluator.cc
@@ -137,7 +137,7 @@ namespace puppet { namespace compiler { namespace evaluation {
         return value;
     }
 
-    value evaluator::operator()(long double value)
+    value evaluator::operator()(double value)
     {
         return value;
     }

--- a/lib/src/compiler/evaluation/operators/divide.cc
+++ b/lib/src/compiler/evaluation/operators/divide.cc
@@ -28,20 +28,20 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return left / right;
         }
 
-        result_type operator()(int64_t left, long double right) const
+        result_type operator()(int64_t left, double right) const
         {
-            return operator()(static_cast<long double>(left), right);
+            return operator()(static_cast<double>(left), right);
         }
 
-        result_type operator()(long double left, int64_t right) const
+        result_type operator()(double left, int64_t right) const
         {
-            return operator()(left, static_cast<long double>(right));
+            return operator()(left, static_cast<double>(right));
         }
 
-        result_type operator()(long double left, long double right) const
+        result_type operator()(double left, double right) const
         {
             feclearexcept(FE_OVERFLOW | FE_UNDERFLOW | FE_DIVBYZERO);
-            long double result = left / right;
+            double result = left / right;
             if (fetestexcept(FE_DIVBYZERO)) {
                 throw evaluation_exception("cannot divide by zero.", _context.right_context());
             } else if (fetestexcept(FE_OVERFLOW)) {
@@ -55,7 +55,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Left,
             typename Right,
-            typename = typename enable_if<(is_same<Left, int64_t>::value || is_same<Left, long double>::value) && !is_same<Right, int64_t>::value && !is_same<Right, long double>::value>::type
+            typename = typename enable_if<(is_same<Left, int64_t>::value || is_same<Left, double>::value) && !is_same<Right, int64_t>::value && !is_same<Right, double>::value>::type
         >
         result_type operator()(int64_t const&, Right const& right) const
         {

--- a/lib/src/compiler/evaluation/operators/greater.cc
+++ b/lib/src/compiler/evaluation/operators/greater.cc
@@ -20,17 +20,17 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return left > right;
         }
 
-        result_type operator()(int64_t left, long double right) const
+        result_type operator()(int64_t left, double right) const
         {
-            return operator()(static_cast<long double>(left), right);
+            return operator()(static_cast<double>(left), right);
         }
 
-        result_type operator()(long double left, int64_t right) const
+        result_type operator()(double left, int64_t right) const
         {
-            return operator()(left, static_cast<long double>(right));
+            return operator()(left, static_cast<double>(right));
         }
 
-        result_type operator()(long double left, long double right) const
+        result_type operator()(double left, double right) const
         {
             return left > right;
         }
@@ -49,7 +49,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
         result_type operator()(int64_t const&, Right const& right) const
         {
@@ -59,9 +59,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
-        result_type operator()(long double const&, Right const& right) const
+        result_type operator()(double const&, Right const& right) const
         {
             throw evaluation_exception((boost::format("expected %1% for comparison but found %2%.") % types::numeric::name() % value(right).get_type()).str(), _context.right_context());
         }

--- a/lib/src/compiler/evaluation/operators/greater_equal.cc
+++ b/lib/src/compiler/evaluation/operators/greater_equal.cc
@@ -20,17 +20,17 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return left >= right;
         }
 
-        result_type operator()(int64_t left, long double right) const
+        result_type operator()(int64_t left, double right) const
         {
-            return operator()(static_cast<long double>(left), right);
+            return operator()(static_cast<double>(left), right);
         }
 
-        result_type operator()(long double left, int64_t right) const
+        result_type operator()(double left, int64_t right) const
         {
-            return operator()(left, static_cast<long double>(right));
+            return operator()(left, static_cast<double>(right));
         }
 
-        result_type operator()(long double left, long double right) const
+        result_type operator()(double left, double right) const
         {
             return left >= right;
         }
@@ -48,7 +48,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
          template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
         result_type operator()(int64_t const&, Right const& right) const
         {
@@ -58,9 +58,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
-        result_type operator()(long double const&, Right const& right) const
+        result_type operator()(double const&, Right const& right) const
         {
             throw evaluation_exception((boost::format("expected %1% for comparison but found %2%.") % types::numeric::name() % value(right).get_type()).str(), _context.right_context());
         }

--- a/lib/src/compiler/evaluation/operators/less.cc
+++ b/lib/src/compiler/evaluation/operators/less.cc
@@ -20,17 +20,17 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return left < right;
         }
 
-        result_type operator()(int64_t left, long double right) const
+        result_type operator()(int64_t left, double right) const
         {
-            return operator()(static_cast<long double>(left), right);
+            return operator()(static_cast<double>(left), right);
         }
 
-        result_type operator()(long double left, int64_t right) const
+        result_type operator()(double left, int64_t right) const
         {
-            return operator()(left, static_cast<long double>(right));
+            return operator()(left, static_cast<double>(right));
         }
 
-        result_type operator()(long double left, long double right) const
+        result_type operator()(double left, double right) const
         {
             return left < right;
         }
@@ -48,7 +48,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
         result_type operator()(int64_t const&, Right const& right) const
         {
@@ -58,9 +58,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
-        result_type operator()(long double const&, Right const& right) const
+        result_type operator()(double const&, Right const& right) const
         {
             throw evaluation_exception((boost::format("expected %1% for comparison but found %2%.") % types::numeric::name() % value(right).get_type()).str(), _context.right_context());
         }

--- a/lib/src/compiler/evaluation/operators/less_equal.cc
+++ b/lib/src/compiler/evaluation/operators/less_equal.cc
@@ -20,17 +20,17 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return left <= right;
         }
 
-        result_type operator()(int64_t left, long double right) const
+        result_type operator()(int64_t left, double right) const
         {
-            return operator()(static_cast<long double>(left), right);
+            return operator()(static_cast<double>(left), right);
         }
 
-        result_type operator()(long double left, int64_t right) const
+        result_type operator()(double left, int64_t right) const
         {
-            return operator()(left, static_cast<long double>(right));
+            return operator()(left, static_cast<double>(right));
         }
 
-        result_type operator()(long double left, long double right) const
+        result_type operator()(double left, double right) const
         {
             return left <= right;
         }
@@ -49,7 +49,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
         result_type operator()(int64_t const&, Right const& right) const
         {
@@ -59,9 +59,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
-        result_type operator()(long double const&, Right const& right) const
+        result_type operator()(double const&, Right const& right) const
         {
             throw evaluation_exception((boost::format("expected %1% for comparison but found %2%.") % types::numeric::name() % value(right).get_type()).str(), _context.right_context());
         }

--- a/lib/src/compiler/evaluation/operators/minus.cc
+++ b/lib/src/compiler/evaluation/operators/minus.cc
@@ -31,20 +31,20 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return left - right;
         }
 
-        result_type operator()(int64_t left, long double right) const
+        result_type operator()(int64_t left, double right) const
         {
-            return operator()(static_cast<long double>(left), right);
+            return operator()(static_cast<double>(left), right);
         }
 
-        result_type operator()(long double left, int64_t right) const
+        result_type operator()(double left, int64_t right) const
         {
-            return operator()(left, static_cast<long double>(right));
+            return operator()(left, static_cast<double>(right));
         }
 
-        result_type operator()(long double left, long double right) const
+        result_type operator()(double left, double right) const
         {
             feclearexcept(FE_OVERFLOW | FE_UNDERFLOW);
-            long double result = left - right;
+            double result = left - right;
             if (fetestexcept(FE_OVERFLOW)) {
                 throw evaluation_exception((boost::format("subtraction of %1% and %2% results in an arithmetic overflow.") % left % right).str(), _context.right_context());
             } else if (fetestexcept(FE_UNDERFLOW)) {
@@ -121,7 +121,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
         result_type operator()(int64_t const&, Right const& right) const
         {
@@ -131,9 +131,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
-        result_type operator()(long double const&, Right const& right) const
+        result_type operator()(double const&, Right const& right) const
         {
             throw evaluation_exception((boost::format("expected %1% for arithmetic subtraction but found %2%.") % types::numeric::name() % value(right).get_type()).str(), _context.right_context());
         }

--- a/lib/src/compiler/evaluation/operators/multiply.cc
+++ b/lib/src/compiler/evaluation/operators/multiply.cc
@@ -41,20 +41,20 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return left * right;
         }
 
-        result_type operator()(int64_t left, long double right) const
+        result_type operator()(int64_t left, double right) const
         {
-            return operator()(static_cast<long double>(left), right);
+            return operator()(static_cast<double>(left), right);
         }
 
-        result_type operator()(long double left, int64_t right) const
+        result_type operator()(double left, int64_t right) const
         {
-            return operator()(left, static_cast<long double>(right));
+            return operator()(left, static_cast<double>(right));
         }
 
-        result_type operator()(long double left, long double right) const
+        result_type operator()(double left, double right) const
         {
             feclearexcept(FE_OVERFLOW | FE_UNDERFLOW);
-            long double result = left * right;
+            double result = left * right;
             if (fetestexcept(FE_OVERFLOW)) {
                 throw evaluation_exception((boost::format("multiplication of %1% and %2% results in an arithmetic overflow.") % left % right).str(), _context.right_context());
             } else if (fetestexcept(FE_UNDERFLOW)) {
@@ -66,7 +66,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
         result_type operator()(int64_t const&, Right const& right) const
         {
@@ -76,9 +76,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
-        result_type operator()(long double const&, Right const& right) const
+        result_type operator()(double const&, Right const& right) const
         {
             throw evaluation_exception((boost::format("expected %1% for arithmetic multiplication but found %2%.") % types::numeric::name() % value(right).get_type()).str(), _context.right_context());
         }

--- a/lib/src/compiler/evaluation/operators/negate.cc
+++ b/lib/src/compiler/evaluation/operators/negate.cc
@@ -23,7 +23,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return -operand;
         }
 
-        result_type operator()(long double operand) const
+        result_type operator()(double operand) const
         {
             return -operand;
         }

--- a/lib/src/compiler/evaluation/operators/plus.cc
+++ b/lib/src/compiler/evaluation/operators/plus.cc
@@ -31,20 +31,20 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return left + right;
         }
 
-        result_type operator()(int64_t left, long double right) const
+        result_type operator()(int64_t left, double right) const
         {
-            return operator()(static_cast<long double>(left), right);
+            return operator()(static_cast<double>(left), right);
         }
 
-        result_type operator()(long double left, int64_t right) const
+        result_type operator()(double left, int64_t right) const
         {
-            return operator()(left, static_cast<long double>(right));
+            return operator()(left, static_cast<double>(right));
         }
 
-        result_type operator()(long double left, long double right) const
+        result_type operator()(double left, double right) const
         {
             feclearexcept(FE_OVERFLOW | FE_UNDERFLOW);
-            long double result = left + right;
+            double result = left + right;
             if (fetestexcept(FE_OVERFLOW)) {
                 throw evaluation_exception((boost::format("addition of %1% and %2% results in an arithmetic overflow.") % left % right).str(), _context.right_context());
             } else if (fetestexcept(FE_UNDERFLOW)) {
@@ -140,7 +140,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
         result_type operator()(int64_t, Right const& right) const
         {
@@ -150,9 +150,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         template <
             typename Right,
             typename = typename enable_if<!is_same<Right, int64_t>::value>::type,
-            typename = typename enable_if<!is_same<Right, long double>::value>::type
+            typename = typename enable_if<!is_same<Right, double>::value>::type
         >
-        result_type operator()(long double, Right const& right) const
+        result_type operator()(double, Right const& right) const
         {
             throw evaluation_exception((boost::format("expected %1% for arithmetic addition but found %2%.") % types::numeric::name() % value(right).get_type()).str(), _context.right_context());
         }

--- a/lib/src/compiler/lexer/number_token.cc
+++ b/lib/src/compiler/lexer/number_token.cc
@@ -19,7 +19,7 @@ namespace puppet { namespace compiler { namespace lexer {
     {
     }
 
-    number_token::number_token(lexer::position position, long double value) :
+    number_token::number_token(lexer::position position, double value) :
         _position(rvalue_cast(position)),
         _value(value),
         _base(numeric_base::decimal)
@@ -70,7 +70,7 @@ namespace puppet { namespace compiler { namespace lexer {
             return _os;
         }
 
-        result_type operator()(long double value) const
+        result_type operator()(double value) const
         {
             return (_os << value);
         }

--- a/lib/src/facts/facter.cc
+++ b/lib/src/facts/facter.cc
@@ -77,7 +77,7 @@ namespace puppet { namespace facts {
         } else if (auto ptr = dynamic_cast<boolean_value const*>(value)) {
             converted = ptr->value();
         } else if (auto ptr = dynamic_cast<double_value const*>(value)) {
-            converted = static_cast<long double>(ptr->value());
+            converted = static_cast<double>(ptr->value());
         } else if (auto ptr = dynamic_cast<array_value const*>(value)) {
             converted = values::array();
             ptr->each([&](::facter::facts::value const* element) {

--- a/lib/src/facts/yaml.cc
+++ b/lib/src/facts/yaml.cc
@@ -102,7 +102,7 @@ namespace puppet { namespace facts {
             } else if (convert<int64_t>::decode(node, int_val)) {
                 value = int_val;
             } else if (convert<double>::decode(node, double_val)) {
-                value = static_cast<long double>(double_val);
+                value = static_cast<double>(double_val);
             } else {
                 // NOTE: as<T> incorrectly returns const T (bug in yaml-cpp), so make the copy explicit
                 string copy = node.as<string>();

--- a/lib/src/runtime/types/floating.cc
+++ b/lib/src/runtime/types/floating.cc
@@ -5,18 +5,18 @@ using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
 
-    floating::floating(long double from, long double to) :
+    floating::floating(double from, double to) :
         _from(from),
         _to(to)
     {
     }
 
-    long double floating::from() const
+    double floating::from() const
     {
         return _from;
     }
 
-    long double floating::to() const
+    double floating::to() const
     {
         return _to;
     }
@@ -28,7 +28,7 @@ namespace puppet { namespace runtime { namespace types {
 
     bool floating::is_instance(values::value const& value) const
     {
-        auto ptr = value.as<long double>();
+        auto ptr = value.as<double>();
         if (!ptr) {
             return false;
         }
@@ -54,8 +54,8 @@ namespace puppet { namespace runtime { namespace types {
     {
         os << floating::name();
         // BUG: fix direct floating point comparison
-        bool from_default = type.from() == numeric_limits<long double>::min();
-        bool to_default = type.to() == numeric_limits<long double>::max();
+        bool from_default = type.from() == numeric_limits<double>::min();
+        bool to_default = type.to() == numeric_limits<double>::max();
         if (from_default && to_default) {
             // Only output the type name
             return os;

--- a/lib/src/runtime/types/numeric.cc
+++ b/lib/src/runtime/types/numeric.cc
@@ -12,7 +12,7 @@ namespace puppet { namespace runtime { namespace types {
 
     bool numeric::is_instance(values::value const& value) const
     {
-        return value.as<int64_t>() || value.as<long double>();
+        return value.as<int64_t>() || value.as<double>();
     }
 
     bool numeric::is_specialization(values::type const& other) const

--- a/lib/src/runtime/values/value.cc
+++ b/lib/src/runtime/values/value.cc
@@ -86,7 +86,7 @@ namespace puppet { namespace runtime { namespace values {
             return types::integer();
         }
 
-        result_type operator()(long double) const
+        result_type operator()(double) const
         {
             return types::floating();
         }
@@ -291,7 +291,7 @@ namespace puppet { namespace runtime { namespace values {
             return value;
         }
 
-        result_type operator()(long double d) const
+        result_type operator()(double d) const
         {
             json_value value;
             value.SetDouble(static_cast<double>(d));

--- a/lib/tests/lexer/lexer.cc
+++ b/lib/tests/lexer/lexer.cc
@@ -96,7 +96,7 @@ void require_number_token(Iterator& token, Iterator const& end, int64_t expected
 }
 
 template <typename Iterator>
-void require_number_token(Iterator& token, Iterator const& end, long double expected_value, string const& expected_string)
+void require_number_token(Iterator& token, Iterator const& end, double expected_value, string const& expected_string)
 {
     CAPTURE(expected_string);
 
@@ -107,7 +107,7 @@ void require_number_token(Iterator& token, Iterator const& end, long double expe
     auto num_token = boost::get<number_token>(&token->value());
     REQUIRE(num_token);
     REQUIRE(num_token->value().which() == 1);
-    REQUIRE(boost::get<long double>(num_token->value()) == Approx(expected_value));
+    REQUIRE(boost::get<double>(num_token->value()) == Approx(expected_value));
     REQUIRE(num_token->base() == numeric_base::decimal);
 
     ostringstream ss;
@@ -408,5 +408,5 @@ SCENARIO("lexing numbers")
     lex_bad_string("123.0e-", 0, 1, "'123.0e-' is not a valid number.");
     lex_bad_string("123.0ebad", 0, 1, "'123.0ebad' is not a valid number.");
     lex_bad_string("123bad.2bad2e-bad", 0, 1, "'123bad.2bad2e-bad' is not a valid number.");
-    lex_bad_string("1e100000", 0, 1, (boost::format("'1e100000' is not in the range of %1% to %2%.") % numeric_limits<long double>::min() % numeric_limits<long double>::max()).str());
+    lex_bad_string("1e100000", 0, 1, (boost::format("'1e100000' is not in the range of %1% to %2%.") % numeric_limits<double>::min() % numeric_limits<double>::max()).str());
 }


### PR DESCRIPTION
On 64-bit Windows, as well as all OSes on POWER, ARM, and SPARC, `long double` is actually just a plain old `double`. It's generally just misleading to anyone reading your code, for very little gain in the couple cases where it is actually a different type. It's better to use a type with more consistent behaviors across all platforms.

Even on x86 Linux and OSX (where it's 80-bits), it sucks. It can't be passed in register arguments, and it actually takes up 16 bytes for alignment reasons - both in structures and on the stack.

Looking further forward, if we wanted to try to make float evaluation more consistent across platforms we could start controlling rounding modes etc. We can't do that if we're using differently-sized floats on different OSes.