### PR TITLE
Remove usage of API fix branch from Dockerfile.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM l3iggs/archlinux
 MAINTAINER Peter Huene <peterhuene@gmail.com>
 RUN pacman -Sy --noconfirm gcc git make cmake boost yaml-cpp && \
     yes | pacman -Scc && \
-    git clone -b fix-api --recursive https://github.com/peterhuene/facter.git /tmp/facter && \
+    git clone --recursive https://github.com/puppetlabs/facter.git /tmp/facter && \
     pushd /tmp/facter && \
     cmake . && \
     make && \


### PR DESCRIPTION
Now that the fix is upstream, remove the use of a clone of facter and instead
use Facter master to build the container.