### PR TITLE
Parser refactoring to support AST range decorations.

### DIFF
--- a/exe/main.cc
+++ b/exe/main.cc
@@ -78,12 +78,12 @@ int main(int argc, char const* argv[])
             catalog.write(output);
 
         } catch (compilation_exception const& ex) {
-            LOG(error, ex.line(), ex.column(), ex.text(), ex.path(), "node '%1%': %2%", node.name(), ex.what());
+            LOG(error, ex.line(), ex.column(), ex.length(), ex.text(), ex.path(), "node '%1%': %2%", node.name(), ex.what());
         } catch (resource_cycle_exception const& ex) {
             LOG(error, ex.what());
         }
     } catch (yaml_parse_exception const& ex) {
-        LOG(error, ex.line(), ex.column(), ex.text(), ex.path(), ex.what());
+        LOG(error, ex.line(), 1, ex.column(), ex.text(), ex.path(), ex.what());
     } catch (settings_exception const& ex) {
         LOG(error, ex.what());
         LOG(notice, "use 'puppetcpp --help' for help.");

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -135,7 +135,13 @@ elseif(WIN32)
 endif()
 
 # Add the executable for generating the static lexer
-add_executable(generate_static_lexer src/compiler/lexer/generate_static_lexer.cc src/compiler/lexer/number_token.cc include/puppet/compiler/lexer/token_id.hpp src/compiler/lexer/token_id.cc src/compiler/lexer/position.cc)
+add_executable(
+    generate_static_lexer
+    src/compiler/lexer/generate_static_lexer.cc
+    src/compiler/lexer/number_token.cc
+    src/compiler/lexer/position.cc
+    src/compiler/lexer/token_id.cc
+)
 target_link_libraries(generate_static_lexer ${Boost_LIBRARIES})
 
 # Add the command to generate the static lexer

--- a/lib/include/puppet/compiler/ast/adapted.hpp
+++ b/lib/include/puppet/compiler/ast/adapted.hpp
@@ -10,115 +10,146 @@
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::undef,
-    context
+    begin,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::defaulted,
-    context
+    begin,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::boolean,
-    context,
-    value
+    begin,
+    value,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::regex,
-    context,
-    value
+    begin,
+    value,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::variable,
-    context,
-    name
+    begin,
+    name,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::name,
-    context,
-    value
+    begin,
+    value,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::bare_word,
-    context,
-    value
+    begin,
+    value,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::type,
-    context,
-    name
+    begin,
+    name,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::array,
-    context,
-    elements
+    begin,
+    elements,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::hash,
-    context,
-    elements
+    begin,
+    elements,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::selector_expression,
-    context,
-    cases
+    begin,
+    cases,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
-    puppet::compiler::ast::case_proposition,
+    puppet::compiler::ast::proposition,
     options,
-    body
+    body,
+    end
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::case_expression,
-    context,
+    begin,
     conditional,
-    propositions
+    propositions,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
-    puppet::compiler::ast::else_expression,
-    context,
-    body
+    puppet::compiler::ast::else_,
+    begin,
+    body,
+    end
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
-    puppet::compiler::ast::elsif_expression,
-    context,
+    puppet::compiler::ast::elsif,
+    begin,
     conditional,
-    body
+    body,
+    end
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::if_expression,
-    context,
+    begin,
     conditional,
     body,
+    end,
     elsifs,
     else_
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::unless_expression,
-    context,
+    begin,
     conditional,
     body,
+    end,
     else_
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::access_expression,
-    context,
-    arguments
+    begin,
+    arguments,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
@@ -131,16 +162,19 @@ BOOST_FUSION_ADAPT_STRUCT(
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::lambda_expression,
-    context,
+    begin,
     parameters,
-    body
+    body,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::method_call_expression,
-    context,
+    begin,
     method,
     arguments,
+    end,
     lambda
 )
 
@@ -148,90 +182,109 @@ BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::function_call_expression,
     function,
     arguments,
-    lambda
+    end,
+    lambda,
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
-    puppet::compiler::ast::attribute,
+    puppet::compiler::ast::attribute_operation,
     name,
-    oper,
+    operator_position,
+    operator_,
     value
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::resource_body,
     title,
-    attributes
+    operations
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::resource_expression,
+    begin,
     status,
     type,
-    bodies
+    bodies,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::resource_override_expression,
+    begin,
     reference,
-    attributes
+    operations,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::resource_defaults_expression,
+    begin,
     type,
-    attributes
+    operations,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::class_expression,
-    context,
+    begin,
     name,
     parameters,
     parent,
-    body
+    body,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::defined_type_expression,
-    context,
+    begin,
     name,
     parameters,
-    body
+    body,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::node_expression,
-    context,
+    begin,
     hostnames,
-    body
+    body,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::attribute_query,
     attribute,
-    oper,
+    operator_position,
+    operator_,
     value
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
-    puppet::compiler::ast::binary_attribute_query,
-    context,
-    oper,
+    puppet::compiler::ast::binary_query_operation,
+    operator_position,
+    operator_,
     operand
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
-    puppet::compiler::ast::collector_query_expression,
+    puppet::compiler::ast::query_expression,
     primary,
-    remainder
+    operations
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::collector_expression,
     type,
     exported,
-    query
+    query,
+    end
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
@@ -242,45 +295,51 @@ BOOST_FUSION_ADAPT_STRUCT(
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::unary_expression,
-    context,
-    oper,
+    operator_position,
+    operator_,
     operand
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
-    puppet::compiler::ast::binary_expression,
-    context,
-    oper,
+    puppet::compiler::ast::binary_operation,
+    operator_position,
+    operator_,
     operand
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::expression,
     postfix,
-    remainder
+    operations
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::epp_render_expression,
-    context,
-    expression
+    begin,
+    expression,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::epp_render_block,
-    context,
-    block
+    begin,
+    block,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::epp_render_string,
-    context,
-    string
+    begin,
+    string,
+    end,
+    tree
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::syntax_tree,
     parameters,
     statements,
-    closing_position
+    end
 )

--- a/lib/include/puppet/compiler/attribute.hpp
+++ b/lib/include/puppet/compiler/attribute.hpp
@@ -23,7 +23,7 @@ namespace puppet { namespace compiler {
          * @param value The attribute's value.
          * @param value_context The AST context of the value.
          */
-        attribute(std::string name, ast::context const& name_context, std::shared_ptr<runtime::values::value> value, ast::context const& value_context);
+        attribute(std::string name, ast::context name_context, std::shared_ptr<runtime::values::value> value, ast::context value_context);
 
         /**
          * Gets the name of the attribute.
@@ -70,9 +70,9 @@ namespace puppet { namespace compiler {
      private:
         std::shared_ptr<ast::syntax_tree> _tree;
         std::string _name;
-        ast::context const& _name_context;
+        ast::context _name_context;
         std::shared_ptr<runtime::values::value> _value;
-        ast::context const& _value_context;
+        ast::context _value_context;
     };
 
     /**

--- a/lib/include/puppet/compiler/catalog.hpp
+++ b/lib/include/puppet/compiler/catalog.hpp
@@ -101,7 +101,7 @@ namespace puppet { namespace compiler {
          * Adds a resource to the catalog.
          * @param type The resource type to add.
          * @param container The container of the resource.
-         * @param context The AST context where the resource was declared.
+         * @param context The optional AST context where the resource was declared.
          * @param virtualized True if the resource is virtualized or false if the resource should be realized.
          * @param exported True if the resource should be exported or false if not.
          * @return Returns a pointer to the resource that was added to the catalog or nullptr if the resource already exists.
@@ -109,7 +109,7 @@ namespace puppet { namespace compiler {
         resource* add(
             runtime::types::resource type,
             resource const* container = nullptr,
-            ast::context const* context = nullptr,
+            boost::optional<ast::context> context = boost::none,
             bool virtualized = false,
             bool exported = false);
 

--- a/lib/include/puppet/compiler/evaluation/collectors/list_collector.hpp
+++ b/lib/include/puppet/compiler/evaluation/collectors/list_collector.hpp
@@ -17,10 +17,15 @@ namespace puppet { namespace compiler { namespace evaluation { namespace collect
     struct list_collector : collector
     {
         /**
+         * The type of the list used by the collector.
+         */
+        using list_type = std::list<std::pair<runtime::types::resource, ast::context>>;
+
+        /**
          * Constructs a list collector.
          * @param list The list of types to collect.
          */
-        list_collector(std::list<std::pair<runtime::types::resource, ast::context>> list);
+        explicit list_collector(list_type list);
 
         /**
          * Collects the resources.
@@ -35,7 +40,8 @@ namespace puppet { namespace compiler { namespace evaluation { namespace collect
         void detect_uncollected() const override;
 
      private:
-        std::list<std::pair<runtime::types::resource, ast::context>> _list;
+        std::shared_ptr<ast::syntax_tree> _tree;
+        list_type _list;
     };
 
 }}}}  // namespace puppet::compiler::evaluation::collectors

--- a/lib/include/puppet/compiler/evaluation/collectors/query_evaluator.hpp
+++ b/lib/include/puppet/compiler/evaluation/collectors/query_evaluator.hpp
@@ -27,7 +27,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace collect
          * @param context The current evaluation context.
          * @param expression The query expression to evaluate.
          */
-        query_evaluator(evaluation::context& context, boost::optional<ast::collector_query_expression> const& expression);
+        query_evaluator(evaluation::context& context, boost::optional<ast::query_expression> const& expression);
 
         /**
          * Evaluates the query against the given resource.
@@ -37,18 +37,18 @@ namespace puppet { namespace compiler { namespace evaluation { namespace collect
         bool evaluate(compiler::resource const& resource) const;
 
      private:
-        bool evaluate(ast::attribute_query_expression const& expression, compiler::resource const& resource) const;
-        void climb_expression(
-            bool& result,
+        bool evaluate(ast::primary_query_expression const& expression, compiler::resource const& resource) const;
+        bool climb_expression(
+            ast::primary_query_expression const& expression,
             std::uint8_t min_precedence,
-            std::vector<ast::binary_attribute_query>::const_iterator& begin,
-            std::vector<ast::binary_attribute_query>::const_iterator const& end,
+            std::vector<ast::binary_query_operation>::const_iterator& begin,
+            std::vector<ast::binary_query_operation>::const_iterator const& end,
             compiler::resource const& resource) const;
         static uint8_t get_precedence(ast::binary_query_operator op);
         static bool is_right_associative(ast::binary_query_operator op);
 
         evaluation::context& _context;
-        boost::optional<ast::collector_query_expression> const& _expression;
+        boost::optional<ast::query_expression> const& _expression;
     };
 
 }}}}  // namespace puppet::compiler::evaluation::collectors

--- a/lib/include/puppet/compiler/evaluation/context.hpp
+++ b/lib/include/puppet/compiler/evaluation/context.hpp
@@ -123,9 +123,9 @@ namespace puppet { namespace compiler { namespace evaluation {
         resource_relationship(
             compiler::relationship relationship,
             runtime::values::value source,
-            ast::context const& source_context,
+            ast::context source_context,
             runtime::values::value target,
-            ast::context const& target_context);
+            ast::context target_context);
 
         /**
          * Gets the relationship between the source and the target.
@@ -164,9 +164,9 @@ namespace puppet { namespace compiler { namespace evaluation {
         std::shared_ptr<ast::syntax_tree> _tree;
         compiler::relationship _relationship;
         runtime::values::value _source;
-        ast::context const& _source_context;
+        ast::context _source_context;
         runtime::values::value _target;
-        ast::context const& _target_context;
+        ast::context _target_context;
     };
 
     /**
@@ -184,7 +184,7 @@ namespace puppet { namespace compiler { namespace evaluation {
          */
         resource_override(
             runtime::types::resource type,
-            ast::context const& context,
+            ast::context context,
             compiler::attributes attributes = compiler::attributes(),
             std::shared_ptr<evaluation::scope> scope = nullptr);
 
@@ -218,7 +218,7 @@ namespace puppet { namespace compiler { namespace evaluation {
 
         std::shared_ptr<ast::syntax_tree> _tree;
         runtime::types::resource _type;
-        ast::context const& _context;
+        ast::context _context;
         compiler::attributes _attributes;
         std::shared_ptr<evaluation::scope> _scope;
     };

--- a/lib/include/puppet/compiler/evaluation/evaluator.hpp
+++ b/lib/include/puppet/compiler/evaluation/evaluator.hpp
@@ -105,28 +105,25 @@ namespace puppet { namespace compiler { namespace evaluation {
 
         runtime::values::value evaluate_body(std::vector<ast::expression> const& body);
         ast::resource_body const* find_default_body(ast::resource_expression const& expression);
-        attributes evaluate_attributes(bool is_class, std::vector<ast::attribute> const& expressions);
-        void splat_attribute(compiler::attributes& attributes, std::unordered_set<std::string>& names, ast::attribute const& expression);
+        attributes evaluate_attributes(bool is_class, std::vector<ast::attribute_operation> const& operations);
+        void splat_attribute(compiler::attributes& attributes, std::unordered_set<std::string>& names, ast::attribute_operation const& operations);
         void validate_attribute(std::string const& name, runtime::values::value& value, ast::context const& context);
         std::vector<resource*> create_resources(bool is_class, std::string const& type_name, ast::resource_expression const& expression, attributes const& defaults);
         void set_attributes(compiler::resource& resource, compiler::attributes const& attributes);
         static runtime::values::type create_relationship_type();
         static runtime::values::type create_audit_type();
 
-        void climb_expression(
-            runtime::values::value& left,
-            ast::context const& context,
+        runtime::values::value climb_expression(
+            ast::postfix_expression const& expression,
             unsigned int min_precedence,
-            std::vector<ast::binary_expression>::const_iterator& begin,
-            std::vector<ast::binary_expression>::const_iterator const& end);
+            std::vector<ast::binary_operation>::const_iterator& begin,
+            std::vector<ast::binary_operation>::const_iterator const& end);
 
         void evaluate(
             runtime::values::value& left,
             ast::context const& left_context,
-            ast::binary_operator op,
-            ast::context const& operator_context,
             runtime::values::value& right,
-            ast::context const& right_context);
+            ast::binary_operation const& operation);
 
         static unsigned int get_precedence(ast::binary_operator op);
         static bool is_right_associative(ast::binary_operator op);

--- a/lib/include/puppet/compiler/evaluation/functions/assert_type.hpp
+++ b/lib/include/puppet/compiler/evaluation/functions/assert_type.hpp
@@ -19,9 +19,6 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
          * @return Returns the resulting value.
          */
         runtime::values::value operator()(function_call_context& context) const;
-
-     private:
-        static bool validate_type(function_call_context& context, runtime::values::type const& type, runtime::values::value& instance, ast::context const& argument_context);
     };
 
 }}}}  // puppet::compiler::evaluation::functions

--- a/lib/include/puppet/compiler/evaluation/functions/function_call_context.hpp
+++ b/lib/include/puppet/compiler/evaluation/functions/function_call_context.hpp
@@ -28,7 +28,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
          * @param context The current evaluation context.
          * @param expression The method call expression.
          * @param instance The value the method is being called on.
-         * @param instance_context The AST context of the instance.
+         * @param instance_context The AST context for the instance.
          * @param splat True if splatting of the instance value is supported or false if not.
          */
         explicit function_call_context(evaluation::context& context, ast::method_call_expression const& expression, runtime::values::value& instance, ast::context const& instance_context, bool splat);
@@ -40,16 +40,10 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         evaluation::context& context() const;
 
         /**
-         * Gets the name of the function being called.
-         * @return Returns the name of the function being called.
+         * Gets the AST name of the function being called.
+         * @return Returns the AST name of the function being called.
          */
-        std::string const& name() const;
-
-        /**
-         * Gets the AST context of the call site.
-         * @return Returns the AST context of the call site.
-         */
-        ast::context const& call_site() const;
+        ast::name const& name() const;
 
         /**
          * Gets the arguments to the function.
@@ -95,12 +89,10 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         void evaluate_arguments(std::vector<ast::expression> const& arguments);
 
         evaluation::context& _context;
-        std::string const& _name;
-        ast::context const& _call_site;
+        ast::name const& _name;
         runtime::values::array _arguments;
-        std::vector<ast::context const*> _argument_contexts;
+        std::vector<ast::context> _argument_contexts;
         boost::optional<ast::lambda_expression> const& _lambda;
     };
-
 
 }}}}  // namespace puppet::compiler::evaluation::functions

--- a/lib/include/puppet/compiler/exceptions.hpp
+++ b/lib/include/puppet/compiler/exceptions.hpp
@@ -29,18 +29,18 @@ namespace puppet { namespace compiler {
         /**
          * Constructs a parse exception.
          * @param message The exception message.
-         * @param position The token position where parsing failed.
+         * @param range The range where parsing failed.
          */
-        parse_exception(std::string const& message, lexer::position position);
+        parse_exception(std::string const& message, lexer::range range);
 
         /**
-         * Gets the token position where parsing failed.
-         * @return Returns the token position where parsing failed.
+         * Gets the range where parsing failed.
+         * @return Returns the range where parsing failed.
          */
-        lexer::position const& position() const;
+        lexer::range const& range() const;
 
     private:
-        lexer::position _position;
+        lexer::range _range;
     };
 
     /**
@@ -57,13 +57,13 @@ namespace puppet { namespace compiler {
         /**
          * Constructs an evaluation exception.
          * @param message The exception message.
-         * @param context The AST context when evaluation failed.
+         * @param context The AST context where evaluation failed.
          */
-        evaluation_exception(std::string const& message, ast::context const& context);
+        evaluation_exception(std::string const& message, ast::context context);
 
         /**
-         * Gets the context where the evaluation failed.
-         * @return Returns the context where evaluation failed.
+         * Gets the AST context where evaluation failed.
+         * @return Returns the AST context where evaluation failed.
          */
         ast::context const& context() const;
 
@@ -83,9 +83,10 @@ namespace puppet { namespace compiler {
          * @param path The path to the input file.
          * @param line The line containing the compilation error.
          * @param column The column containing the compilation error.
+         * @param length The length of the compilation error.
          * @param text The line of text containing the compilation error.
          */
-        explicit compilation_exception(std::string const& message, std::string path = std::string(), size_t line = 0, size_t column = 0, std::string text = std::string());
+        explicit compilation_exception(std::string const& message, std::string path = std::string(), size_t line = 0, size_t column = 0, size_t length = 0, std::string text = std::string());
 
         /**
          * Constructs a compilation exception from a parse exception.
@@ -119,6 +120,12 @@ namespace puppet { namespace compiler {
         size_t column() const;
 
         /**
+         * Gets the length of the compilation error.
+         * @return Returns the length of the compilation error.
+         */
+        size_t length() const;
+
+        /**
          * Gets the line of text containing the compilation error.
          * @return Returns the line of text containing the compilation error.
          */
@@ -128,6 +135,7 @@ namespace puppet { namespace compiler {
         std::string _path;
         size_t _line;
         size_t _column;
+        size_t _length;
         std::string _text;
     };
 

--- a/lib/include/puppet/compiler/lexer/number_token.hpp
+++ b/lib/include/puppet/compiler/lexer/number_token.hpp
@@ -48,24 +48,24 @@ namespace puppet { namespace compiler { namespace lexer {
 
         /**
          * Constructs a number token with the given position and integral value.
-         * @param position The position of the token.
+         * @param range The range of the token.
          * @param value The integral value of the token.
          * @param base The numeric base of the token.
          */
-        number_token(lexer::position position, std::int64_t value, numeric_base base);
+        number_token(lexer::range range, std::int64_t value, numeric_base base);
 
         /**
          * Constructs a number token with the given position and floating point value.
-         * @param position The position of the token.
+         * @param range The range of the token.
          * @param value The floating point value of the token.
          */
-        number_token(lexer::position position, double value);
+        number_token(lexer::range range, double value);
 
         /**
-         * Gets the position of the token.
-         * @return Returns the position of the token.
+         * Gets the range of the token.
+         * @return Returns the range of the token.
          */
-        lexer::position const& position() const;
+        lexer::range const& range() const;
 
         /**
          * Gets the value of the token.
@@ -80,7 +80,7 @@ namespace puppet { namespace compiler { namespace lexer {
         numeric_base base() const;
 
      private:
-        lexer::position _position;
+        lexer::range _range;
         value_type _value;
         numeric_base _base;
     };

--- a/lib/include/puppet/compiler/lexer/position.hpp
+++ b/lib/include/puppet/compiler/lexer/position.hpp
@@ -50,6 +50,65 @@ namespace puppet { namespace compiler { namespace lexer {
     };
 
     /**
+     * Represents a range within a lexed input.
+     */
+    struct range
+    {
+        /**
+         * Default constructor for range.
+         */
+        range() = default;
+
+        /**
+         * Constructs a range with the given begin and end positions.
+         * @param begin The beginning position of the range.
+         * @param end The ending position of the range.
+         */
+        range(position begin, position end);
+
+        /**
+         * Constructs a range with the given beginning position and length.
+         * @param begin The beginning position of the range.
+         * @param length The length of the range.
+         */
+        range(position begin, size_t length);
+
+        /**
+         * Gets the beginning position of the range.
+         * @return Returns the beginning position of the range.
+         */
+        position const& begin() const;
+
+        /**
+         * Sets the beginning position of the range.
+         * @param begin The beginning position of the range.
+         */
+        void begin(position begin);
+
+        /**
+         * Gets the ending position of the range.
+         * @return Returns the ending position of the range.
+         */
+        position const& end() const;
+
+        /**
+         * Sets the ending position of the range.
+         * @param end The ending position of the range.
+         */
+        void end(position end);
+
+        /**
+         * Gets the length of the range, in bytes.
+         * @return Returns the length of the range, in bytes.
+         */
+        size_t length() const;
+
+     private:
+        position _begin;
+        position _end;
+    };
+
+    /**
      * Stream insertion operator for position.
      * @param os The output stream to write the position to.
      * @param position The position to write.

--- a/lib/include/puppet/compiler/lexer/string_token.hpp
+++ b/lib/include/puppet/compiler/lexer/string_token.hpp
@@ -26,20 +26,14 @@ namespace puppet { namespace compiler { namespace lexer {
         using iterator_type = Iterator;
 
         /**
-         * Constructs an empty string token.
+         * The string value type.
          */
-        string_token() :
-            _interpolated(true),
-            _margin(0),
-            _remove_break(false)
-        {
-        }
+        using value_type = boost::iterator_range<Iterator>;
 
         /**
          * Constructs a string token.
-         * @param position The position in the input source for the token.
-         * @param begin The begin iterator for the string text.
-         * @param end The end iterator for the string text.
+         * @param range The token's range.
+         * @param value The iterator range for the string's value.
          * @param escapes The valid escape characters for the string token.
          * @param quote The quoting character for the string; null character for heredocs.
          * @param interpolated True if the string should be interpolated or false if not.
@@ -47,10 +41,9 @@ namespace puppet { namespace compiler { namespace lexer {
          * @param margin The margin for the string (heredoc only).
          * @param remove_break Remove a trailing line break from the string (heredoc only).
          */
-        string_token(lexer::position position, iterator_type begin, iterator_type end, std::string escapes, char quote, bool interpolated = true, std::string format = std::string(), int margin = 0, bool remove_break = false) :
-            _position(rvalue_cast(position)),
-            _begin(rvalue_cast(begin)),
-            _end(rvalue_cast(end)),
+        string_token(lexer::range range, value_type value, std::string escapes, char quote, bool interpolated = true, std::string format = std::string(), int margin = 0, bool remove_break = false) :
+            _range(rvalue_cast(range)),
+            _value(rvalue_cast(value)),
             _escapes(rvalue_cast(escapes)),
             _quote(quote),
             _interpolated(interpolated),
@@ -61,30 +54,21 @@ namespace puppet { namespace compiler { namespace lexer {
         }
 
         /**
-         * Gets the position of the token.
-         * @return Returns the position of the token.
+         * Gets the range of the token.
+         * @return Returns the range of the token.
          */
-        lexer::position const& position() const
+        lexer::range const& range() const
         {
-            return _position;
+            return _range;
         }
 
         /**
-         * Gets the begin iterator for the string text.
-         * @return Returns the begin iterator for the string text.
+         * Gets the iterator range representing the string value.
+         * @return Returns the iterator range representing the string value.
          */
-        iterator_type const& begin() const
+        value_type const& value() const
         {
-            return _begin;
-        }
-
-        /**
-         * Gets the end iterator for the string text.
-         * @return Returns the end iterator for the string text.
-         */
-        iterator_type const& end() const
-        {
-            return _end;
+            return _value;
         }
 
         /**
@@ -143,9 +127,8 @@ namespace puppet { namespace compiler { namespace lexer {
         }
 
      private:
-        lexer::position _position;
-        iterator_type _begin;
-        iterator_type _end;
+        lexer::range _range;
+        value_type _value;
         std::string _escapes;
         char _quote;
         bool _interpolated;
@@ -164,7 +147,7 @@ namespace puppet { namespace compiler { namespace lexer {
     template <typename Iterator>
     std::ostream& operator<<(std::ostream& os, string_token<Iterator> const& token)
     {
-        os << (token.interpolated() ? '"' : '\'') << boost::make_iterator_range(token.begin(), token.end()) << (token.interpolated() ? '"' : '\'');
+        os << (token.interpolated() ? '"' : '\'') << token.value() << (token.interpolated() ? '"' : '\'');
         return os;
     }
 

--- a/lib/include/puppet/compiler/parser/rules.hpp
+++ b/lib/include/puppet/compiler/parser/rules.hpp
@@ -29,6 +29,8 @@ namespace puppet { namespace compiler { namespace parser {
     DECLARE_RULE(undef,                         "undef",                         ast::undef)
     DECLARE_RULE(defaulted,                     "default",                       ast::defaulted)
     DECLARE_RULE(boolean,                       "boolean",                       ast::boolean)
+    DECLARE_RULE(literal_true,                  "true",                          ast::boolean)
+    DECLARE_RULE(literal_false,                 "false",                         ast::boolean)
     DECLARE_RULE(number,                        "number",                        ast::number)
     DECLARE_RULE(string,                        "string",                        ast::string)
     DECLARE_RULE(regex,                         "regex",                         ast::regex)
@@ -41,10 +43,10 @@ namespace puppet { namespace compiler { namespace parser {
     DECLARE_RULE(pairs,                         "pairs",                         std::vector<ast::pair>)
     DECLARE_RULE(pair,                          "pair",                          ast::pair)
     DECLARE_RULE(case_expression,               "case expression",               ast::case_expression)
-    DECLARE_RULE(case_proposition,              "case proposition",              ast::case_proposition)
+    DECLARE_RULE(proposition,                   "proposition",                   ast::proposition)
     DECLARE_RULE(if_expression,                 "if expression",                 ast::if_expression)
-    DECLARE_RULE(elsif_expression,              "elsif expression",              ast::elsif_expression)
-    DECLARE_RULE(else_expression,               "else expression",               ast::else_expression)
+    DECLARE_RULE(elsif,                         "elsif",                         ast::elsif)
+    DECLARE_RULE(else_,                         "else",                          ast::else_)
     DECLARE_RULE(unless_expression,             "unless expression",             ast::unless_expression)
     DECLARE_RULE(function_call_expression,      "function call expression",      ast::function_call_expression)
     DECLARE_RULE(parameters,                    "parameters",                    std::vector<ast::parameter>)
@@ -54,12 +56,14 @@ namespace puppet { namespace compiler { namespace parser {
     DECLARE_RULE(statement_call_expression,     "statement call expression",     ast::function_call_expression)
     DECLARE_RULE(statement_call_name,           "name",                          ast::name)
     DECLARE_RULE(resource_expression,           "resource expression",           ast::resource_expression)
+    DECLARE_RULE(virtualized_resource,          "virtualized resource",          ast::resource_expression)
+    DECLARE_RULE(exported_resource,             "exported resource",             ast::resource_expression)
     DECLARE_RULE(resource_type,                 "resource type",                 ast::postfix_expression)
     DECLARE_RULE(class_name,                    "name",                          ast::name)
     DECLARE_RULE(resource_bodies,               "resource bodies",               std::vector<ast::resource_body>)
     DECLARE_RULE(resource_body,                 "resource body",                 ast::resource_body)
-    DECLARE_RULE(attributes,                    "attributes",                    std::vector<ast::attribute>)
-    DECLARE_RULE(attribute,                     "attribute",                     ast::attribute)
+    DECLARE_RULE(attributes,                    "attributes",                    std::vector<ast::attribute_operation>)
+    DECLARE_RULE(attribute,                     "attribute",                     ast::attribute_operation)
     DECLARE_RULE(attribute_operator,            "attribute operator",            ast::attribute_operator)
     DECLARE_RULE(attribute_name,                "attribute name",                ast::name)
     DECLARE_RULE(keyword_name,                  "name",                          ast::name)
@@ -73,12 +77,12 @@ namespace puppet { namespace compiler { namespace parser {
     DECLARE_RULE(hostname,                      "hostname",                      ast::hostname)
     DECLARE_RULE(collector_expression,          "resource collector",            ast::collector_expression)
     DECLARE_RULE(exported_collector_expression, "exported resource collector",   ast::collector_expression)
-    DECLARE_RULE(collector_query_expression,    "collector query expression",    ast::collector_query_expression)
-    DECLARE_RULE(attribute_query_expression,    "attribute query expression",    ast::attribute_query_expression)
+    DECLARE_RULE(query_expression,              "query expression",              ast::query_expression)
+    DECLARE_RULE(primary_query_expression,      "primary query expression",      ast::primary_query_expression)
     DECLARE_RULE(attribute_query,               "attribute query",               ast::attribute_query)
-    DECLARE_RULE(attribute_query_operator,      "attribute query operator",      ast::attribute_query_operator)
+    DECLARE_RULE(query_operator,                "query operator",                ast::query_operator)
     DECLARE_RULE(attribute_query_value,         "attribute value",               ast::primary_expression)
-    DECLARE_RULE(binary_attribute_query,        "binary attribute query",        ast::binary_attribute_query)
+    DECLARE_RULE(binary_query_operation,        "binary query expression",       ast::binary_query_operation)
     DECLARE_RULE(binary_query_operator,         "binary query operator",         ast::binary_query_operator)
     DECLARE_RULE(unary_expression,              "unary expression",              ast::unary_expression)
     DECLARE_RULE(unary_operator,                "unary operator",                ast::unary_operator)
@@ -91,11 +95,11 @@ namespace puppet { namespace compiler { namespace parser {
     DECLARE_RULE(statement,                     "statement",                     ast::expression)
     DECLARE_RULE(postfix_statement,             "postfix statement",             ast::postfix_expression)
     DECLARE_RULE(primary_statement,             "primary statement",             ast::primary_expression)
-    DECLARE_RULE(binary_statement,              "binary statement",              ast::binary_expression)
+    DECLARE_RULE(binary_statement,              "binary statement",              ast::binary_operation)
     DECLARE_RULE(binary_operator,               "binary operator",               ast::binary_operator)
     DECLARE_RULE(expressions,                   "expressions",                   std::vector<ast::expression>)
     DECLARE_RULE(expression,                    "expression",                    ast::expression)
-    DECLARE_RULE(binary_expression,             "binary expression",             ast::binary_expression)
+    DECLARE_RULE(binary_expression,             "binary expression",             ast::binary_operation)
     DECLARE_RULE(primary_expression,            "primary expression",            ast::primary_expression)
     DECLARE_RULE(syntax_tree,                   "syntax tree",                   ast::syntax_tree)
     DECLARE_RULE(interpolated_syntax_tree,      "syntax tree",                   ast::syntax_tree)
@@ -105,143 +109,107 @@ namespace puppet { namespace compiler { namespace parser {
     DECLARE_RULE(epp_syntax_tree,               "syntax tree",                   ast::syntax_tree)
 
     // Literal rules
-    // Note: the use of `eps` is to assist in populating a single-member fusion structure;
-    //       without it, the attribute would be assigned directly instead of via fusion.
     DEFINE_RULE(
         undef,
-        boost::spirit::x3::eps >> context(lexer::token_id::keyword_undef)
+        begin(lexer::token_id::keyword_undef, false) > end() > tree
     )
     DEFINE_RULE(
         defaulted,
-        boost::spirit::x3::eps >> context(lexer::token_id::keyword_default)
+        begin(lexer::token_id::keyword_default, false) > end() > tree
     )
     DEFINE_RULE(
         boolean,
-        (context(lexer::token_id::keyword_true) > boost::spirit::x3::attr(true)) |
-        (context(lexer::token_id::keyword_false) > boost::spirit::x3::attr(false))
+        literal_true | literal_false
+    )
+    DEFINE_RULE(
+        literal_true,
+        begin(lexer::token_id::keyword_true, false) > boost::spirit::x3::attr(true) > end() > tree
+    )
+    DEFINE_RULE(
+        literal_false,
+        begin(lexer::token_id::keyword_false, false) > boost::spirit::x3::attr(false) > end() > tree
     )
     DEFINE_RULE(
         number,
-        number_token()
+        number_token
     )
     DEFINE_RULE(
         string,
-        string_token(lexer::token_id::single_quoted_string) |
-        string_token(lexer::token_id::double_quoted_string) |
-        string_token(lexer::token_id::heredoc)
+        string_token
     )
     DEFINE_RULE(
         regex,
-        context(lexer::token_id::regex, false) > token(lexer::token_id::regex, true, true)
+        begin(lexer::token_id::regex, false) > trim_value > end() > tree
     )
     DEFINE_RULE(
         variable,
-        context(lexer::token_id::variable, false) > token(lexer::token_id::variable, true)
+        begin(lexer::token_id::variable, false) > ltrim_value > end() > tree
     )
     DEFINE_RULE(
         name,
-        (context(lexer::token_id::name, false) > token(lexer::token_id::name)) |
-        statement_call_name
+        (begin(lexer::token_id::name, false) > value > end() > tree) | statement_call_name
     )
     DEFINE_RULE(
         bare_word,
-        context(lexer::token_id::bare_word, false) > token(lexer::token_id::bare_word)
+        begin(lexer::token_id::bare_word, false) > value > end() > tree
     )
     DEFINE_RULE(
         type,
-        context(lexer::token_id::type, false) > token(lexer::token_id::type)
+        begin(lexer::token_id::type, false) > value > end() > tree
     )
     DEFINE_RULE(
         array,
-        (
-            context('[') |
-            context(lexer::token_id::array_start)
-        ) >
-        (
-            raw_token(']') |
-            (expressions > raw_token(']'))
-        )
+        (begin('[') | begin(lexer::token_id::array_start)) > (raw(']', false) | expressions) > end(']') > tree
     )
     DEFINE_RULE(
         hash,
-        context('{') >
-        (
-            raw_token('}') |
-            (pairs > raw_token('}'))
-        )
+        begin('{') > (raw('}', false) | pairs) > end('}') > tree
     )
     DEFINE_RULE(
         pairs,
-        (pair % raw_token(',')) > -raw_token(',')
+        (pair % raw(',')) > -raw(',')
     )
     DEFINE_RULE(
         pair,
-        expression > raw_token(lexer::token_id::fat_arrow) > expression
+        expression > raw(lexer::token_id::fat_arrow) > expression
     )
 
     // Control-flow expressions
     DEFINE_RULE(
         case_expression,
-        context(lexer::token_id::keyword_case) > expression > raw_token('{') > +case_proposition > raw_token('}')
+        begin(lexer::token_id::keyword_case) > expression > raw('{') > +proposition > end('}') > tree
     )
     DEFINE_RULE(
-        case_proposition,
-        expressions > raw_token(':') > raw_token('{') >
-        (
-            raw_token('}') |
-            (statements > raw_token('}'))
-        )
+        proposition,
+        expressions > raw(':') > raw('{') > (raw('}', false) | statements) > end('}')
     )
     DEFINE_RULE(
         if_expression,
-        context(lexer::token_id::keyword_if) > expression > raw_token('{') >
-        (
-            raw_token('}') |
-            (statements > raw_token('}'))
-        ) > *elsif_expression > -else_expression
+        begin(lexer::token_id::keyword_if) > expression > raw('{') > (raw('}', false) | statements) > end('}') > *elsif > -else_
     )
     DEFINE_RULE(
-        elsif_expression,
-        context(lexer::token_id::keyword_elsif) > expression > raw_token('{') >
-        (
-            raw_token('}') |
-            (statements > raw_token('}'))
-        )
+        elsif,
+        begin(lexer::token_id::keyword_elsif) > expression > raw('{') > (raw('}', false) | statements) > end('}')
     )
     DEFINE_RULE(
-        else_expression,
-        context(lexer::token_id::keyword_else) > raw_token('{') >
-        (
-            raw_token('}') |
-            (statements > raw_token('}'))
-        )
+        else_,
+        begin(lexer::token_id::keyword_else) > raw('{') > (raw('}', false) | statements) > end('}')
     )
     DEFINE_RULE(
         unless_expression,
-        context(lexer::token_id::keyword_unless) > expression > raw_token('{') >
-        (
-            raw_token('}') |
-            (statements > raw_token('}'))
-        ) > -else_expression
+        begin(lexer::token_id::keyword_unless) > expression > raw('{') > (raw('}', false) | statements) > end('}') > -else_
     )
     DEFINE_RULE(
         function_call_expression,
-        name >>
-        (
-            raw_token('(') >
-            (
-                raw_token(')') |
-                (expressions > raw_token(')')
-            )
-        ) > -lambda_expression)
+        name >> (raw('(') > (raw(')', false) | expressions) > end(')') > -lambda_expression)
     )
     DEFINE_RULE(
         parameters,
-        (parameter % raw_token(',')) > -raw_token(',')
+        (parameter % raw(',')) > -raw(',')
     )
     DEFINE_RULE(
         parameter,
-        -type_expression >> boost::spirit::x3::matches[raw_token('*')] >> (variable > -(raw_token('=') > expression))
+        -type_expression >> -begin('*') >> (variable > -(raw('=') > expression))
     )
     DEFINE_RULE(
         type_expression,
@@ -249,40 +217,31 @@ namespace puppet { namespace compiler { namespace parser {
     )
     DEFINE_RULE(
         lambda_expression,
-        context('|') >
-        (
-            raw_token('|') |
-            (parameters > raw_token('|'))
-        ) > raw_token('{') >
-        (
-            raw_token('}') |
-            (statements > raw_token('}'))
-        )
+        begin('|') > (raw('|', false) | parameters) > raw('|') > raw('{') > (raw('}', false) | statements) > end('}') > tree
     )
     DEFINE_RULE(
         statement_call_expression,
-        statement_call_name >> !raw_token('(') >> expressions >> -lambda_expression
+        statement_call_name >> !raw('(') >> (expressions > boost::spirit::x3::attr(boost::none) > -lambda_expression)
     )
     DEFINE_RULE(
         statement_call_name,
-        context(lexer::token_id::statement_call, false) > token(lexer::token_id::statement_call)
+        begin(lexer::token_id::statement_call, false) > value > end() > tree
     )
 
     // Catalog expressions
     DEFINE_RULE(
         resource_expression,
-        (
-            (raw_token('@')                   > boost::spirit::x3::attr(ast::resource_status::virtualized)) |
-            (raw_token(lexer::token_id::atat) > boost::spirit::x3::attr(ast::resource_status::exported))    |
-            (boost::spirit::x3::eps           > boost::spirit::x3::attr(ast::resource_status::realized))
-        ) >> resource_type >>
-        (
-            raw_token('{') >
-            (
-                raw_token('}') |
-                (resource_bodies > raw_token('}'))
-            )
-        )
+        virtualized_resource |
+        exported_resource |
+        (begin(false) >> boost::spirit::x3::attr(ast::resource_status::realized) >> resource_type >> (raw('{') > (raw('}', false) | resource_bodies) > end('}') > tree))
+    )
+    DEFINE_RULE(
+        virtualized_resource,
+        begin('@') > boost::spirit::x3::attr(ast::resource_status::virtualized) > resource_type > raw('{') > (raw('}', false) | resource_bodies) > end('}') > tree
+    )
+    DEFINE_RULE(
+        exported_resource,
+        begin(lexer::token_id::atat) > boost::spirit::x3::attr(ast::resource_status::exported) > resource_type > raw('{') > (raw('}', false) | resource_bodies) > end('}') > tree
     )
     DEFINE_RULE(
         resource_type,
@@ -291,67 +250,65 @@ namespace puppet { namespace compiler { namespace parser {
     )
     DEFINE_RULE(
         class_name,
-        context(lexer::token_id::keyword_class, false) > token(lexer::token_id::keyword_class)
+        begin(lexer::token_id::keyword_class, false) > value > end() > tree
     )
     DEFINE_RULE(
         resource_bodies,
-        (resource_body % raw_token(';')) > -raw_token(';')
+        (resource_body % raw(';')) > -raw(';')
     )
     DEFINE_RULE(
         resource_body,
-        primary_expression > raw_token(':') > (attributes | boost::spirit::x3::eps)
+        primary_expression > raw(':') > (attributes | boost::spirit::x3::eps)
     )
     DEFINE_RULE(
         attributes,
-        (attribute % raw_token(',')) > -raw_token(',')
+        (attribute % raw(',')) > -raw(',')
     )
     DEFINE_RULE(
         attribute,
-        attribute_name > attribute_operator > expression
+        attribute_name > begin(false) > attribute_operator > expression
     )
     DEFINE_RULE(
         attribute_operator,
-        (raw_token(lexer::token_id::fat_arrow)  > boost::spirit::x3::attr(ast::attribute_operator::assignment)) |
-        (raw_token(lexer::token_id::plus_arrow) > boost::spirit::x3::attr(ast::attribute_operator::append))
+        (raw(lexer::token_id::fat_arrow)  > boost::spirit::x3::attr(ast::attribute_operator::assignment)) |
+        (raw(lexer::token_id::plus_arrow) > boost::spirit::x3::attr(ast::attribute_operator::append))
     )
     DEFINE_RULE(
         attribute_name,
         name                |
         statement_call_name |
         keyword_name        |
-        (context('*', false) > token('*'))
+        (begin('*', false) > value > end() > tree)
     )
     DEFINE_RULE(
         keyword_name,
-        (context(lexer::token_id::keyword_and, false)      > token(lexer::token_id::keyword_and))      |
-        (context(lexer::token_id::keyword_case, false)     > token(lexer::token_id::keyword_case))     |
-        (context(lexer::token_id::keyword_class, false)    > token(lexer::token_id::keyword_class))    |
-        (context(lexer::token_id::keyword_default, false)  > token(lexer::token_id::keyword_default))  |
-        (context(lexer::token_id::keyword_define, false)   > token(lexer::token_id::keyword_define))   |
-        (context(lexer::token_id::keyword_else, false)     > token(lexer::token_id::keyword_else))     |
-        (context(lexer::token_id::keyword_elsif, false)    > token(lexer::token_id::keyword_elsif))    |
-        (context(lexer::token_id::keyword_if, false)       > token(lexer::token_id::keyword_if))       |
-        (context(lexer::token_id::keyword_in, false)       > token(lexer::token_id::keyword_in))       |
-        (context(lexer::token_id::keyword_inherits, false) > token(lexer::token_id::keyword_inherits)) |
-        (context(lexer::token_id::keyword_node, false)     > token(lexer::token_id::keyword_node))     |
-        (context(lexer::token_id::keyword_or, false)       > token(lexer::token_id::keyword_or))       |
-        (context(lexer::token_id::keyword_undef, false)    > token(lexer::token_id::keyword_undef))    |
-        (context(lexer::token_id::keyword_unless, false)   > token(lexer::token_id::keyword_unless))   |
-        (context(lexer::token_id::keyword_type, false)     > token(lexer::token_id::keyword_type))     |
-        (context(lexer::token_id::keyword_attr, false)     > token(lexer::token_id::keyword_attr))     |
-        (context(lexer::token_id::keyword_function, false) > token(lexer::token_id::keyword_function)) |
-        (context(lexer::token_id::keyword_private, false)  > token(lexer::token_id::keyword_private))
+        (
+            // NOTE: keywords 'true' and 'false' are not valid names
+            begin(lexer::token_id::keyword_and, false)      |
+            begin(lexer::token_id::keyword_case, false)     |
+            begin(lexer::token_id::keyword_class, false)    |
+            begin(lexer::token_id::keyword_default, false)  |
+            begin(lexer::token_id::keyword_define, false)   |
+            begin(lexer::token_id::keyword_else, false)     |
+            begin(lexer::token_id::keyword_elsif, false)    |
+            begin(lexer::token_id::keyword_if, false)       |
+            begin(lexer::token_id::keyword_in, false)       |
+            begin(lexer::token_id::keyword_inherits, false) |
+            begin(lexer::token_id::keyword_node, false)     |
+            begin(lexer::token_id::keyword_or, false)       |
+            begin(lexer::token_id::keyword_undef, false)    |
+            begin(lexer::token_id::keyword_unless, false)   |
+            begin(lexer::token_id::keyword_type, false)     |
+            begin(lexer::token_id::keyword_attr, false)     |
+            begin(lexer::token_id::keyword_function, false) |
+            begin(lexer::token_id::keyword_private, false)
+        ) > value > end() > tree
     )
+    // Ensure all keywords (except true/false) are present in the list above
+    static_assert((static_cast<size_t>(lexer::token_id::last_keyword) - static_cast<size_t>(lexer::token_id::first_keyword)) == (20 + 1), "a keyword is missing from the keyword_name rule.");
     DEFINE_RULE(
         resource_override_expression,
-        resource_reference_expression >>
-        (
-            raw_token('{') >
-            (
-                raw_token('}') |
-                (attributes > raw_token('}'))
-            )
-        )
+        begin(false) >> resource_reference_expression >> (raw('{') > (raw('}', false) | attributes) > end('}') > tree)
     )
     DEFINE_RULE(
         resource_reference_expression,
@@ -359,94 +316,63 @@ namespace puppet { namespace compiler { namespace parser {
     )
     DEFINE_RULE(
         resource_defaults_expression,
-        type >>
-        (
-            raw_token('{') >
-            (
-                raw_token('}') |
-                (attributes > raw_token('}'))
-            )
-        )
+        begin(false) >> type >> (raw('{') > (raw('}', false) | attributes) > end('}') > tree)
     )
     DEFINE_RULE(
         class_expression,
-        context(lexer::token_id::keyword_class) > name >
-        (
-            (raw_token('(') >> raw_token(')'))             |
-            (raw_token('(') > parameters > raw_token(')')) |
-            boost::spirit::x3::eps
-        ) > -(raw_token(lexer::token_id::keyword_inherits) > name) > raw_token('{') >
-        (
-            raw_token('}') |
-            (statements > raw_token('}'))
-        )
+        begin(lexer::token_id::keyword_class) >
+        name >
+        -(raw('(') > (raw(')', false) | parameters) > raw(')')) >
+        -(raw(lexer::token_id::keyword_inherits) > name) >
+        raw('{') > (raw('}', false) | statements) > end('}') > tree
     )
     DEFINE_RULE(
         defined_type_expression,
-        context(lexer::token_id::keyword_define) > name >
-        (
-            (raw_token('(') >> raw_token(')'))             |
-            (raw_token('(') > parameters > raw_token(')')) |
-            boost::spirit::x3::eps
-        ) > raw_token('{') >
-        (
-            raw_token('}') |
-            (statements > raw_token('}'))
-        )
+        begin(lexer::token_id::keyword_define) >
+        name >
+        -(raw('(') > (raw(')', false) | parameters) >raw(')')) >
+        raw('{') > (raw('}', false) | statements) > end('}') > tree
     )
     DEFINE_RULE(
         node_expression,
-        context(lexer::token_id::keyword_node) > hostnames > raw_token('{') >
-        (
-            raw_token('}') |
-            (statements > raw_token('}'))
-        )
+        begin(lexer::token_id::keyword_node) > hostnames > raw('{') > (raw('}', false) | statements) > end('}') > tree
     )
     DEFINE_RULE(
         hostnames,
-        (hostname % ',') > -raw_token(',')
+        (hostname % ',') > -raw(',')
     )
     DEFINE_RULE(
         hostname,
         string    |
         defaulted |
         regex     |
-        ((name | bare_word | number) % raw_token('.'))
+        ((name | bare_word | number) % raw('.'))
     )
     DEFINE_RULE(
         collector_expression,
-        type >>
-        (
-            (raw_token(lexer::token_id::left_collect) > boost::spirit::x3::attr(false)) >
-            -collector_query_expression >
-            raw_token(lexer::token_id::right_collect)
-        )
+        type >> (raw(lexer::token_id::left_collect) > boost::spirit::x3::attr(false) > -query_expression > end(lexer::token_id::right_collect))
     )
     DEFINE_RULE(
         exported_collector_expression,
-        type >>
-        (
-            (raw_token(lexer::token_id::left_double_collect) > boost::spirit::x3::attr(true)) >
-            -collector_query_expression >
-            raw_token(lexer::token_id::right_double_collect)
-        )
+        type >> (raw(lexer::token_id::left_double_collect) > boost::spirit::x3::attr(true) > -query_expression > end(lexer::token_id::right_double_collect))
     )
     DEFINE_RULE(
-        collector_query_expression,
-        attribute_query_expression > *binary_attribute_query
+        query_expression,
+        primary_query_expression > *binary_query_operation
     )
     DEFINE_RULE(
-        attribute_query_expression,
-        attribute_query | (raw_token('(') > collector_query_expression > raw_token(')'))
+        primary_query_expression,
+        attribute_query |
+        (raw('(') > query_expression > raw(')'))
     )
     DEFINE_RULE(
         attribute_query,
-        name > attribute_query_operator > attribute_query_value
+        name > begin(false) > query_operator > attribute_query_value
     )
     DEFINE_RULE(
-        attribute_query_operator,
-        (raw_token(lexer::token_id::equals)     > boost::spirit::x3::attr(ast::attribute_query_operator::equals)) |
-        (raw_token(lexer::token_id::not_equals) > boost::spirit::x3::attr(ast::attribute_query_operator::not_equals))
+        query_operator,
+        (raw(lexer::token_id::equals)     > boost::spirit::x3::attr(ast::query_operator::equals)) |
+        (raw(lexer::token_id::not_equals) > boost::spirit::x3::attr(ast::query_operator::not_equals))
     )
     DEFINE_RULE(
         attribute_query_value,
@@ -464,25 +390,25 @@ namespace puppet { namespace compiler { namespace parser {
         hash
     )
     DEFINE_RULE(
-        binary_attribute_query,
-        current_context >> (binary_query_operator > attribute_query_expression)
+        binary_query_operation,
+        begin(false) >> (binary_query_operator > primary_query_expression)
     )
     DEFINE_RULE(
         binary_query_operator,
-        (raw_token(lexer::token_id::keyword_and) > boost::spirit::x3::attr(ast::binary_query_operator::logical_and)) |
-        (raw_token(lexer::token_id::keyword_or)  > boost::spirit::x3::attr(ast::binary_query_operator::logical_or))
+        (raw(lexer::token_id::keyword_and) > boost::spirit::x3::attr(ast::binary_query_operator::logical_and)) |
+        (raw(lexer::token_id::keyword_or)  > boost::spirit::x3::attr(ast::binary_query_operator::logical_or))
     )
 
     // Unary expressions
     DEFINE_RULE(
         unary_expression,
-        current_context >> (unary_operator > postfix_expression)
+        begin(false) >> (unary_operator > postfix_expression)
     )
     DEFINE_RULE(
         unary_operator,
-        (raw_token('-') > boost::spirit::x3::attr(ast::unary_operator::negate))     |
-        (raw_token('*') > boost::spirit::x3::attr(ast::unary_operator::splat))      |
-        (raw_token('!') > boost::spirit::x3::attr(ast::unary_operator::logical_not))
+        (raw('-') > boost::spirit::x3::attr(ast::unary_operator::negate))     |
+        (raw('*') > boost::spirit::x3::attr(ast::unary_operator::splat))      |
+        (raw('!') > boost::spirit::x3::attr(ast::unary_operator::logical_not))
     )
 
     // Postfix expressions
@@ -496,26 +422,21 @@ namespace puppet { namespace compiler { namespace parser {
     )
     DEFINE_RULE(
         selector_expression,
-        context('?') > raw_token('{') > pairs > raw_token('}')
+        begin('?') > raw('{') > pairs > end('}') > tree
     )
     DEFINE_RULE(
         access_expression,
-        context('[') > expressions > raw_token(']')
+        begin('[') > expressions > end(']') > tree
     )
     DEFINE_RULE(
         method_call_expression,
-        context('.') > name >
-        (
-            (raw_token('(') >> raw_token(')')) |
-            (raw_token('(') > expressions > raw_token(')')) |
-            boost::spirit::x3::eps
-        ) > -lambda_expression
+        begin('.') > name > -(raw('(') > (raw(')', false) | expressions) > end(')')) > -lambda_expression
     )
 
     // Statement rules
     DEFINE_RULE(
         statements,
-        (statement % -raw_token(';')) > -raw_token(';')
+        (statement % -raw(';')) > -raw(';')
     )
     DEFINE_RULE(
         statement,
@@ -538,39 +459,39 @@ namespace puppet { namespace compiler { namespace parser {
     )
     DEFINE_RULE(
         binary_statement,
-        current_context >> (binary_operator > postfix_expression)
+        begin(false) >> (binary_operator > postfix_statement)
     )
     DEFINE_RULE(
         binary_operator,
-        (raw_token(lexer::token_id::keyword_in)     > boost::spirit::x3::attr(ast::binary_operator::in))                 |
-        (raw_token(lexer::token_id::match)          > boost::spirit::x3::attr(ast::binary_operator::match))              |
-        (raw_token(lexer::token_id::not_match)      > boost::spirit::x3::attr(ast::binary_operator::not_match))          |
-        (raw_token('*')                             > boost::spirit::x3::attr(ast::binary_operator::multiply))           |
-        (raw_token('/')                             > boost::spirit::x3::attr(ast::binary_operator::divide))             |
-        (raw_token('%')                             > boost::spirit::x3::attr(ast::binary_operator::modulo))             |
-        (raw_token('+')                             > boost::spirit::x3::attr(ast::binary_operator::plus))               |
-        (raw_token('-')                             > boost::spirit::x3::attr(ast::binary_operator::minus))              |
-        (raw_token(lexer::token_id::left_shift)     > boost::spirit::x3::attr(ast::binary_operator::left_shift))         |
-        (raw_token(lexer::token_id::right_shift)    > boost::spirit::x3::attr(ast::binary_operator::right_shift))        |
-        (raw_token(lexer::token_id::equals)         > boost::spirit::x3::attr(ast::binary_operator::equals))             |
-        (raw_token(lexer::token_id::not_equals)     > boost::spirit::x3::attr(ast::binary_operator::not_equals))         |
-        (raw_token('>')                             > boost::spirit::x3::attr(ast::binary_operator::greater_than))       |
-        (raw_token(lexer::token_id::greater_equals) > boost::spirit::x3::attr(ast::binary_operator::greater_equals))     |
-        (raw_token('<')                             > boost::spirit::x3::attr(ast::binary_operator::less_than))          |
-        (raw_token(lexer::token_id::less_equals)    > boost::spirit::x3::attr(ast::binary_operator::less_equals))        |
-        (raw_token(lexer::token_id::keyword_and)    > boost::spirit::x3::attr(ast::binary_operator::logical_and))        |
-        (raw_token(lexer::token_id::keyword_or)     > boost::spirit::x3::attr(ast::binary_operator::logical_or))         |
-        (raw_token('=')                             > boost::spirit::x3::attr(ast::binary_operator::assignment))         |
-        (raw_token(lexer::token_id::in_edge)        > boost::spirit::x3::attr(ast::binary_operator::in_edge))            |
-        (raw_token(lexer::token_id::in_edge_sub)    > boost::spirit::x3::attr(ast::binary_operator::in_edge_subscribe))  |
-        (raw_token(lexer::token_id::out_edge)       > boost::spirit::x3::attr(ast::binary_operator::out_edge))           |
-        (raw_token(lexer::token_id::out_edge_sub)   > boost::spirit::x3::attr(ast::binary_operator::out_edge_subscribe))
+        (raw(lexer::token_id::keyword_in)     > boost::spirit::x3::attr(ast::binary_operator::in))                 |
+        (raw(lexer::token_id::match)          > boost::spirit::x3::attr(ast::binary_operator::match))              |
+        (raw(lexer::token_id::not_match)      > boost::spirit::x3::attr(ast::binary_operator::not_match))          |
+        (raw('*')                             > boost::spirit::x3::attr(ast::binary_operator::multiply))           |
+        (raw('/')                             > boost::spirit::x3::attr(ast::binary_operator::divide))             |
+        (raw('%')                             > boost::spirit::x3::attr(ast::binary_operator::modulo))             |
+        (raw('+')                             > boost::spirit::x3::attr(ast::binary_operator::plus))               |
+        (raw('-')                             > boost::spirit::x3::attr(ast::binary_operator::minus))              |
+        (raw(lexer::token_id::left_shift)     > boost::spirit::x3::attr(ast::binary_operator::left_shift))         |
+        (raw(lexer::token_id::right_shift)    > boost::spirit::x3::attr(ast::binary_operator::right_shift))        |
+        (raw(lexer::token_id::equals)         > boost::spirit::x3::attr(ast::binary_operator::equals))             |
+        (raw(lexer::token_id::not_equals)     > boost::spirit::x3::attr(ast::binary_operator::not_equals))         |
+        (raw('>')                             > boost::spirit::x3::attr(ast::binary_operator::greater_than))       |
+        (raw(lexer::token_id::greater_equals) > boost::spirit::x3::attr(ast::binary_operator::greater_equals))     |
+        (raw('<')                             > boost::spirit::x3::attr(ast::binary_operator::less_than))          |
+        (raw(lexer::token_id::less_equals)    > boost::spirit::x3::attr(ast::binary_operator::less_equals))        |
+        (raw(lexer::token_id::keyword_and)    > boost::spirit::x3::attr(ast::binary_operator::logical_and))        |
+        (raw(lexer::token_id::keyword_or)     > boost::spirit::x3::attr(ast::binary_operator::logical_or))         |
+        (raw('=')                             > boost::spirit::x3::attr(ast::binary_operator::assignment))         |
+        (raw(lexer::token_id::in_edge)        > boost::spirit::x3::attr(ast::binary_operator::in_edge))            |
+        (raw(lexer::token_id::in_edge_sub)    > boost::spirit::x3::attr(ast::binary_operator::in_edge_subscribe))  |
+        (raw(lexer::token_id::out_edge)       > boost::spirit::x3::attr(ast::binary_operator::out_edge))           |
+        (raw(lexer::token_id::out_edge_sub)   > boost::spirit::x3::attr(ast::binary_operator::out_edge_subscribe))
     )
 
     // Expression rules
     DEFINE_RULE(
         expressions,
-        (expression % raw_token(',')) > -raw_token(',')
+        (expression % raw(',')) > -raw(',')
     )
     DEFINE_RULE(
         expression,
@@ -578,7 +499,7 @@ namespace puppet { namespace compiler { namespace parser {
     )
     DEFINE_RULE(
         binary_expression,
-        current_context >> (binary_operator > postfix_expression)
+        begin(false) >> (binary_operator > postfix_expression)
     )
     // Note: literal expressions must come last because some complex expressions depend on them
     // Note: parsing of EPP render block must come before EPP render expression
@@ -606,7 +527,7 @@ namespace puppet { namespace compiler { namespace parser {
         type                          |
         array                         |
         hash                          |
-        (raw_token('(') > expression > raw_token(')'))
+        (raw('(') > expression > raw(')'))
     )
     DEFINE_RULE(
         syntax_tree,
@@ -614,31 +535,25 @@ namespace puppet { namespace compiler { namespace parser {
     )
     DEFINE_RULE(
         interpolated_syntax_tree,
-        boost::spirit::x3::attr(boost::none) > raw_token('{') > statements > position('}')
+        boost::spirit::x3::attr(boost::none) > raw('{') > statements > end('}')
     )
 
     // EPP rules
     DEFINE_RULE(
         epp_render_expression,
-        context(lexer::token_id::epp_render_expression) > expression > (raw_token(lexer::token_id::epp_end) | raw_token(lexer::token_id::epp_end_trim))
+        begin(lexer::token_id::epp_render_expression) > expression > (end(lexer::token_id::epp_end) | end(lexer::token_id::epp_end_trim)) > tree
     )
     DEFINE_RULE(
         epp_render_block,
-        context(lexer::token_id::epp_render_expression) >> (raw_token('{') > statements > raw_token('}') > (raw_token(lexer::token_id::epp_end) | raw_token(lexer::token_id::epp_end_trim)))
+        begin(lexer::token_id::epp_render_expression) >> (raw('{') > statements > raw('}') > (end(lexer::token_id::epp_end) | end(lexer::token_id::epp_end_trim)) > tree)
     )
     DEFINE_RULE(
         epp_render_string,
-        context(lexer::token_id::epp_render_string, false) > token(lexer::token_id::epp_render_string)
+        begin(lexer::token_id::epp_render_string, false) > value > end() > tree
     )
     DEFINE_RULE(
         epp_syntax_tree,
-        -(
-            raw_token('|') >
-            (
-                raw_token('|') |
-                (parameters > raw_token('|'))
-            )
-        ) > statements > boost::spirit::x3::attr(lexer::position())
+        -(raw('|') > (raw('|', false) | parameters) > raw('|')) > statements > boost::spirit::x3::attr(lexer::position())
     )
 
     // These macros associate the above rules with their definitions
@@ -647,6 +562,8 @@ namespace puppet { namespace compiler { namespace parser {
         undef,
         defaulted,
         boolean,
+        literal_true,
+        literal_false,
         number,
         string,
         regex,
@@ -662,10 +579,10 @@ namespace puppet { namespace compiler { namespace parser {
 
     BOOST_SPIRIT_DEFINE(
         case_expression,
-        case_proposition,
+        proposition,
         if_expression,
-        elsif_expression,
-        else_expression,
+        elsif,
+        else_,
         unless_expression,
         function_call_expression,
         parameters,
@@ -678,6 +595,8 @@ namespace puppet { namespace compiler { namespace parser {
 
     BOOST_SPIRIT_DEFINE(
         resource_expression,
+        virtualized_resource,
+        exported_resource,
         resource_type,
         class_name,
         resource_bodies,
@@ -697,12 +616,12 @@ namespace puppet { namespace compiler { namespace parser {
         hostname,
         collector_expression,
         exported_collector_expression,
-        collector_query_expression,
-        attribute_query_expression,
+        query_expression,
+        primary_query_expression,
         attribute_query,
-        attribute_query_operator,
+        query_operator,
         attribute_query_value,
-        binary_attribute_query,
+        binary_query_operation,
         binary_query_operator
     );
 
@@ -733,7 +652,7 @@ namespace puppet { namespace compiler { namespace parser {
         epp_render_block,
         epp_render_string,
         epp_syntax_tree
-    )
+    );
 
     /// @endcond
 

--- a/lib/include/puppet/compiler/resource.hpp
+++ b/lib/include/puppet/compiler/resource.hpp
@@ -139,7 +139,7 @@ namespace puppet { namespace compiler {
      private:
         friend struct catalog;
 
-        resource(runtime::types::resource type, resource const* container, ast::context const* context, bool exported);
+        resource(runtime::types::resource type, resource const* container, boost::optional<ast::context> context, bool exported);
         runtime::values::json_value to_json(runtime::values::json_allocator& allocator, compiler::catalog const& catalog) const;
         void add_relationship_parameters(runtime::values::json_value& parameters, runtime::values::json_allocator& allocator, compiler::catalog const& catalog) const;
         void realize(size_t vertex_id);
@@ -149,7 +149,7 @@ namespace puppet { namespace compiler {
         std::shared_ptr<ast::syntax_tree> _tree;
         runtime::types::resource _type;
         resource const* _container;
-        ast::context const* _context;
+        boost::optional<ast::context> _context;
         size_t _vertex_id;
         std::unordered_map<std::string, std::shared_ptr<attribute>> _attributes;
         std::vector<std::string> _tags;

--- a/lib/include/puppet/compiler/scanner.hpp
+++ b/lib/include/puppet/compiler/scanner.hpp
@@ -57,8 +57,8 @@ namespace puppet { namespace compiler {
         void operator()(ast::defined_type_expression const& expression);
         void operator()(ast::node_expression const& expression);
         void operator()(ast::collector_expression const& expression);
-        void operator()(ast::collector_query_expression const& expression);
-        void operator()(ast::attribute_query_expression const& expression);
+        void operator()(ast::query_expression const& expression);
+        void operator()(ast::primary_query_expression const& expression);
         void operator()(ast::attribute_query const& expression);
         void operator()(ast::unary_expression const& expression);
         void operator()(ast::postfix_expression const& expression);

--- a/lib/include/puppet/logging/logger.hpp
+++ b/lib/include/puppet/logging/logger.hpp
@@ -99,11 +99,12 @@ namespace puppet { namespace logging {
          * @param level The log level.
          * @param line The line of the source context.
          * @param column The column of the source context.
+         * @param length The length of the source to highlight.
          * @param text The context text.
          * @param path The path of the source file.
          * @param message The message to log.
          */
-        void log(logging::level level, size_t line, size_t column, std::string const& text, std::string const& path, std::string const& message);
+        void log(logging::level level, size_t line, size_t column, size_t length, std::string const& text, std::string const& path, std::string const& message);
 
         /**
          * Logs a message.
@@ -119,7 +120,7 @@ namespace puppet { namespace logging {
                 return;
             }
             boost::format message(format);
-            log(level, 0, 0, {}, {}, message, std::forward<TArgs>(args)...);
+            log(level, 0, 0, 0, {}, {}, message, std::forward<TArgs>(args)...);
         }
 
         /**
@@ -128,19 +129,20 @@ namespace puppet { namespace logging {
          * @param level The log level.
          * @param line The line of the source context.
          * @param column The column of the source context.
+         * @param length The length of the source to highlight.
          * @param text The context text.
          * @param path The path of the source file.
          * @param format The format of the message to log.
          * @param args The format arguments.
          */
         template <typename... TArgs>
-        void log(logging::level level, size_t line, size_t column, std::string const& text, std::string const& path, std::string const& format, TArgs... args)
+        void log(logging::level level, size_t line, size_t column, size_t length, std::string const& text, std::string const& path, std::string const& format, TArgs... args)
         {
             if (!would_log(level)) {
                 return;
             }
             boost::format message(format);
-            log(level, line, column, text, path, message, std::forward<TArgs>(args)...);
+            log(level, line, column, length, text, path, message, std::forward<TArgs>(args)...);
         }
 
         /**
@@ -185,20 +187,21 @@ namespace puppet { namespace logging {
          * @param level The log level.
          * @param line The line of the source context.
          * @param column The column of the source context.
+         * @param length The length of the source to highlight.
          * @param text The context text.
          * @param path The path of the source file.
          * @param message The message to log.
          */
-        virtual void log_message(logging::level level, size_t line, size_t column, std::string const& text, std::string const& path, std::string const& message) = 0;
+        virtual void log_message(logging::level level, size_t line, size_t column, size_t length, std::string const& text, std::string const& path, std::string const& message) = 0;
 
      private:
-        void log(logging::level level, size_t line, size_t column, std::string const& text, std::string const& path, boost::format& message);
+        void log(logging::level level, size_t line, size_t column, size_t length, std::string const& text, std::string const& path, boost::format& message);
 
         template <typename T, typename... TArgs>
-        void log(logging::level level, size_t line, size_t column, std::string const& text, std::string const& path, boost::format& message, T arg, TArgs... args)
+        void log(logging::level level, size_t line, size_t column, size_t length, std::string const& text, std::string const& path, boost::format& message, T arg, TArgs... args)
         {
             message % std::forward<T>(arg);
-            log(level, line, column, text, path, message, std::forward<TArgs>(args)...);
+            log(level, line, column, length, text, path, message, std::forward<TArgs>(args)...);
         }
 
         size_t _warnings;
@@ -217,11 +220,12 @@ namespace puppet { namespace logging {
          * @param level The log level.
          * @param line The line of the source context.
          * @param column The column of the source context.
+         * @param length The length of the source to highlight.
          * @param text The context text.
          * @param path The path of the source file.
          * @param message The message to log.
          */
-        virtual void log_message(logging::level level, size_t line, size_t column, std::string const& text, std::string const& path, std::string const& message) override;
+        virtual void log_message(logging::level level, size_t line, size_t column, size_t length, std::string const& text, std::string const& path, std::string const& message) override;
 
         /**
          * Gets the stream to log to based on the message's log level.

--- a/lib/include/puppet/runtime/values/type.hpp
+++ b/lib/include/puppet/runtime/values/type.hpp
@@ -204,9 +204,9 @@ namespace puppet { namespace runtime { namespace values {
          * Creates a type from a Puppet type expression.
          * @param context The current evaluation context.
          * @param expression The expression to parse for the type.
-         * @return Returns the type if the parse was successful or throws puppet::compiler::parse_exception.
+         * @return Returns the type if the parse was successful or boost::none if the parsing failed.
          */
-        static type parse(compiler::evaluation::context& context, std::string const& expression);
+        static boost::optional<type> parse(compiler::evaluation::context& context, std::string const& expression);
 
      private:
         type_variant _value;

--- a/lib/src/compiler/attribute.cc
+++ b/lib/src/compiler/attribute.cc
@@ -6,15 +6,19 @@ using namespace puppet::runtime;
 
 namespace puppet { namespace compiler {
 
-    attribute::attribute(string name, ast::context const& name_context, shared_ptr<values::value> value, ast::context const& value_context) :
-        _tree(name_context.tree->shared_from_this()),
+    attribute::attribute(string name, ast::context name_context, shared_ptr<values::value> value, ast::context value_context) :
         _name(rvalue_cast(name)),
-        _name_context(name_context),
+        _name_context(rvalue_cast(name_context)),
         _value(rvalue_cast(value)),
-        _value_context(value_context)
+        _value_context(rvalue_cast(value_context))
     {
         if (!_value) {
             throw runtime_error("expected an attribute value.");
+        }
+        if (_name_context.tree) {
+            _tree = _name_context.tree->shared_from_this();
+        } else if (_value_context.tree) {
+            _tree = _value_context.tree->shared_from_this();
         }
     }
 

--- a/lib/src/compiler/catalog.cc
+++ b/lib/src/compiler/catalog.cc
@@ -64,7 +64,7 @@ namespace puppet { namespace compiler {
         return _environment;
     }
 
-    resource* catalog::add(types::resource type, resource const* container, ast::context const* context, bool virtualized, bool exported)
+    resource* catalog::add(types::resource type, resource const* container, boost::optional<ast::context> context, bool virtualized, bool exported)
     {
         // Ensure the resource name is fully qualified
         if (!type.fully_qualified()) {
@@ -81,7 +81,7 @@ namespace puppet { namespace compiler {
             return nullptr;
         }
 
-        _resources.emplace_back(resource(rvalue_cast(type), container, context, exported));
+        _resources.emplace_back(resource(rvalue_cast(type), container, rvalue_cast(context), exported));
 
         auto resource = &_resources.back();
 

--- a/lib/src/compiler/environment.cc
+++ b/lib/src/compiler/environment.cc
@@ -127,7 +127,7 @@ namespace puppet { namespace compiler {
             auto resource = catalog.add(
                 types::resource("node", result.second),
                 catalog.find(types::resource("class", "main")),
-                &result.first->expression().context);
+                result.first->expression());
             if (!resource) {
                 throw evaluation_exception("failed to add node resource.");
             }

--- a/lib/src/compiler/evaluation/access_evaluator.cc
+++ b/lib/src/compiler/evaluation/access_evaluator.cc
@@ -317,7 +317,7 @@ namespace puppet { namespace compiler { namespace evaluation {
         {
             // At least 2 and at most 4 arguments to Hash
             if (_arguments.size() < 2) {
-                throw evaluation_exception((boost::format("expected at least 2 arguments for %1% but %2% were given.") % types::hash::name() % _arguments.size()).str(), _expression.context);
+                throw evaluation_exception((boost::format("expected at least 2 arguments for %1% but %2% were given.") % types::hash::name() % _arguments.size()).str(), _expression);
             }
             if (_arguments.size() > 4) {
                 throw evaluation_exception((boost::format("expected at most 3 arguments for %1% but %2% were given.") % types::hash::name() % _arguments.size()).str(), _contexts[4]);
@@ -593,7 +593,7 @@ namespace puppet { namespace compiler { namespace evaluation {
         template <typename T>
         value operator()(T const& target)
         {
-            throw evaluation_exception((boost::format("access expression is not supported for %1%.") % value(target).get_type()).str(), _expression.context);
+            throw evaluation_exception((boost::format("access expression is not supported for %1%.") % value(target).get_type()).str(), _expression);
         }
 
         template <typename Value, typename Type>
@@ -678,7 +678,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             // Find the resource
             auto resource = catalog.find(target);
             if (!resource) {
-                throw evaluation_exception((boost::format("resource %1% does not exist in the catalog.") % target).str(), _expression.context);
+                throw evaluation_exception((boost::format("resource %1% does not exist in the catalog.") % target).str(), _expression);
             }
 
             // Check for single access

--- a/lib/src/compiler/evaluation/call_evaluator.cc
+++ b/lib/src/compiler/evaluation/call_evaluator.cc
@@ -52,7 +52,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                     throw evaluation_exception((boost::format("parameter $%1% \"captures rest\" but is not the last parameter.") % name).str(), parameter.context());
                 }
                 if (parameter.type) {
-                    throw evaluation_exception((boost::format("parameter $%1% \"captures rest\" and cannot have a type specifier.") % name).str(), parameter.context());
+                    throw evaluation_exception((boost::format("parameter $%1% \"captures rest\" and cannot have a type specifier.") % name).str(), parameter.type->context());
                 }
                 values::array captured;
                 if (i < arguments.size()) {
@@ -81,7 +81,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 } else {
                     // Check for not present and without a default value
                     if (!parameter.default_value) {
-                        throw evaluation_exception((boost::format("parameter $%1% is required but no value was given.") % name).str(), parameter.context());
+                        throw evaluation_exception((boost::format("parameter $%1% is required but no value was given.") % name).str(), parameter.variable);
                     }
 
                     value = evaluator.evaluate(*parameter.default_value);
@@ -93,7 +93,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 }
             }
 
-            if (current_scope->set(name, std::make_shared<values::value>(rvalue_cast(value)), parameter.context())) {
+            if (current_scope->set(name, std::make_shared<values::value>(rvalue_cast(value)), parameter.variable)) {
                 throw evaluation_exception((boost::format("parameter $%1% already exists in the parameter list.") % name).str(), parameter.context());
             }
         }
@@ -119,7 +119,7 @@ namespace puppet { namespace compiler { namespace evaluation {
 
             // If there's no default value, the parameter is required
             if (!parameter.default_value) {
-                throw evaluation_exception((boost::format("parameter $%1% is required but no value was given.") % name).str(), parameter.context());
+                throw evaluation_exception((boost::format("parameter $%1% is required but no value was given.") % name).str(), parameter.variable);
             }
 
             // Evaluate the default value
@@ -130,8 +130,8 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(rvalue_cast(message), parameter.default_value->context());
             });
 
-            if (current_scope->set(name, std::make_shared<values::value>(rvalue_cast(value)), parameter.context())) {
-                throw evaluation_exception((boost::format("parameter $%1% already exists in the parameter list.") % name).str(), parameter.context());
+            if (current_scope->set(name, std::make_shared<values::value>(rvalue_cast(value)), parameter.variable)) {
+                throw evaluation_exception((boost::format("parameter $%1% already exists in the parameter list.") % name).str(), parameter.variable);
             }
         }
 
@@ -149,7 +149,7 @@ namespace puppet { namespace compiler { namespace evaluation {
 
             // Check for illegal "captures rest"
             if (parameter->captures) {
-                throw evaluation_exception((boost::format("parameter $%1% cannot \"captures rest\".") % *name).str(), parameter->context());
+                throw evaluation_exception((boost::format("parameter $%1% cannot \"captures rest\".") % *name).str(), parameter->variable);
             }
 
             // Verify the value matches the parameter type
@@ -157,8 +157,8 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw argument_exception(rvalue_cast(message), index);
             });
 
-            if (current_scope->set(*name, std::make_shared<values::value>(rvalue_cast(kvp.value())), parameter->context())) {
-                throw evaluation_exception((boost::format("parameter $%1% already exists in the parameter list.") % *name).str(), parameter->context());
+            if (current_scope->set(*name, std::make_shared<values::value>(rvalue_cast(kvp.value())), parameter->variable)) {
+                throw evaluation_exception((boost::format("parameter $%1% already exists in the parameter list.") % *name).str(), parameter->variable);
             }
         }
         return evaluate_body();
@@ -194,7 +194,7 @@ namespace puppet { namespace compiler { namespace evaluation {
 
             // If there's no default value, the parameter is required
             if (!parameter.default_value) {
-                throw evaluation_exception((boost::format("parameter $%1% is required but no value was given.") % name).str(), parameter.context());
+                throw evaluation_exception((boost::format("parameter $%1% is required but no value was given.") % name).str(), parameter.variable);
             }
 
             // Evaluate the default value
@@ -208,7 +208,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             // Set the parameter as an attribute on the resource
             resource.set(std::make_shared<attribute>(
                 parameter.variable.name,
-                parameter.context(),
+                parameter.variable,
                 std::make_shared<values::value>(rvalue_cast(value)),
                 parameter.default_value->context()
             ));

--- a/lib/src/compiler/evaluation/collectors/list_collector.cc
+++ b/lib/src/compiler/evaluation/collectors/list_collector.cc
@@ -9,9 +9,13 @@ using namespace puppet::runtime;
 
 namespace puppet { namespace compiler { namespace evaluation { namespace collectors {
 
-    list_collector::list_collector(list<pair<types::resource, ast::context>> list) :
+    list_collector::list_collector(list_type list) :
         _list(rvalue_cast(list))
     {
+        // Take a shared reference on the AST (assumes all entries in the list come from the same AST)
+        if (!_list.empty()) {
+            _tree = _list.front().second.tree->shared_from_this();
+        }
     }
 
     void list_collector::detect_uncollected() const

--- a/lib/src/compiler/evaluation/dispatcher.cc
+++ b/lib/src/compiler/evaluation/dispatcher.cc
@@ -58,7 +58,7 @@ namespace puppet { namespace compiler { namespace evaluation {
         // TODO: check a local collection of "registered" functions first
 
         // Find a builtin function
-        auto it = builtin_functions.find(context.name());
+        auto it = builtin_functions.find(context.name().value);
         if (it == builtin_functions.end()) {
             if (_fallback) {
                 auto result = _fallback(context);
@@ -66,7 +66,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                     return rvalue_cast(*result);
                 }
             }
-            throw evaluation_exception((boost::format("unknown function '%1%'.") % context.name()).str(), context.call_site());
+            throw evaluation_exception((boost::format("unknown function '%1%'.") % context.name()).str(), context.name());
         }
         return it->second(context);
     }

--- a/lib/src/compiler/evaluation/functions/assert_type.cc
+++ b/lib/src/compiler/evaluation/functions/assert_type.cc
@@ -9,13 +9,26 @@ using namespace puppet::runtime;
 
 namespace puppet { namespace compiler { namespace evaluation { namespace functions {
 
+    static bool validate_type(function_call_context& context, values::type const& type, values::value& instance, ast::context const& argument_context)
+    {
+        if (type.is_instance(instance)) {
+            return true;
+        }
+
+        // Otherwise, a lambda is required
+        if (!context.lambda()) {
+            throw evaluation_exception((boost::format("type assertion failure: expected %1% but found %2%.") % type % instance.get_type()).str(), argument_context);
+        }
+        return false;
+    }
+
     values::value assert_type::operator()(function_call_context& context) const
     {
         // Check the argument count
         auto& arguments = context.arguments();
         size_t count = arguments.size();
         if (count != 2) {
-            throw evaluation_exception((boost::format("expected 2 arguments to '%1%' function but %2% were given.") % context.name() % count).str(), count > 2 ? context.argument_context(2) : context.call_site());
+            throw evaluation_exception((boost::format("expected 2 arguments to '%1%' function but %2% were given.") % context.name() % count).str(), count > 2 ? context.argument_context(2) : context.name());
         }
 
         auto& first = context.argument(0);
@@ -28,14 +41,13 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                 return rvalue_cast(second);
             }
         } else if (auto str = first.as<string>()) {
-            try {
-                auto type = values::type::parse(context.context(), *str);
-                // If the value is an instance of the type, return it
-                if (validate_type(context, type, second, context.argument_context(1))) {
-                    return rvalue_cast(second);
-                }
-            } catch (parse_exception const& ex) {
-                throw evaluation_exception(ex.what(), context.argument_context(0));
+            auto type = values::type::parse(context.context(), *str);
+            if (!type) {
+                throw evaluation_exception((boost::format("the expression '%1%' is not a valid type specification.") % *str).str(), context.argument_context(0));
+            }
+            // If the value is an instance of the type, return it
+            if (validate_type(context, *type, second, context.argument_context(1))) {
+                return rvalue_cast(second);
             }
         } else {
             throw evaluation_exception((boost::format("expected %1% or %2% for first argument but found %3%.") % types::type::name() % types::string::name() % first.get_type()).str(), context.argument_context(0));
@@ -44,19 +56,6 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         // Call the lambda and give it the type of the argument
         second = second.get_type();
         return context.yield(arguments);
-    }
-
-    bool assert_type::validate_type(function_call_context& context, values::type const& type, values::value& instance, ast::context const& argument_context)
-    {
-        if (type.is_instance(instance)) {
-            return true;
-        }
-
-        // Otherwise, a lambda is required
-        if (!context.lambda()) {
-            throw evaluation_exception((boost::format("type assertion failure: expected %1% but found %2%.") % type % instance.get_type()).str(), argument_context);
-        }
-        return false;
     }
 
 }}}}  // namespace puppet::compiler::evaluation::functions

--- a/lib/src/compiler/evaluation/functions/declare.cc
+++ b/lib/src/compiler/evaluation/functions/declare.cc
@@ -99,7 +99,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
     {
         auto& arguments = context.arguments();
         if (arguments.empty()) {
-            throw evaluation_exception((boost::format("expected at least one argument to '%1%' function.") % context.name()).str(), context.call_site());
+            throw evaluation_exception((boost::format("expected at least one argument to '%1%' function.") % context.name()).str(), context.name());
         }
         for (size_t i = 0; i < arguments.size(); ++i) {
             boost::apply_visitor(declare_visitor(context, context.argument_context(i), _relationship), arguments[i]);

--- a/lib/src/compiler/evaluation/functions/defined.cc
+++ b/lib/src/compiler/evaluation/functions/defined.cc
@@ -22,7 +22,11 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
 
             // Check for variable lookup
             if (boost::starts_with(argument, "$")) {
-                ast::variable variable{ _argument_context, argument };
+                ast::variable variable;
+                variable.begin = _argument_context.begin;
+                variable.end = _argument_context.end;
+                variable.tree = _argument_context.tree;
+                variable.name = argument.substr(1);
                 return context.lookup(variable, false).get();
             }
 
@@ -125,7 +129,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         // Ensure there is at least one argument
         auto& arguments = context.arguments();
         if (arguments.empty()) {
-            throw evaluation_exception((boost::format("expected at least one argument to '%1%' function.") % context.name()).str(), context.call_site());
+            throw evaluation_exception((boost::format("expected at least one argument to '%1%' function.") % context.name()).str(), context.name());
         }
 
         // Return true if any argument is defined

--- a/lib/src/compiler/evaluation/functions/each.cc
+++ b/lib/src/compiler/evaluation/functions/each.cc
@@ -130,17 +130,17 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                     context.name() %
                     arguments.size()
                 ).str(),
-                arguments.size() > 1 ? context.argument_context(1) : context.call_site()
+                arguments.size() > 1 ? context.argument_context(1) : context.name()
             );
         }
 
         // Check the lambda
         if (!context.lambda()) {
-            throw evaluation_exception((boost::format("expected a lambda to '%1%' function but one was not given.") % context.name()).str(), context.call_site());
+            throw evaluation_exception((boost::format("expected a lambda to '%1%' function but one was not given.") % context.name()).str(), context.name());
         }
         auto count = context.lambda()->parameters.size();
         if (count == 0 || count > 2) {
-            throw evaluation_exception((boost::format("expected 1 or 2 lambda parameters but %1% were given.") % count).str(), context.lambda()->context);
+            throw evaluation_exception((boost::format("expected 1 or 2 lambda parameters but %1% were specified.") % count).str(), *context.lambda());
         }
 
         // Visit the argument and return it

--- a/lib/src/compiler/evaluation/functions/fail.cc
+++ b/lib/src/compiler/evaluation/functions/fail.cc
@@ -15,7 +15,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
             ss << ": ";
             context.arguments().join(ss, " ");
         }
-        throw evaluation_exception(ss.str(), context.call_site());
+        throw evaluation_exception(ss.str(), context.name());
     }
 
 }}}}  // namespace puppet::compiler::evaluation::functions

--- a/lib/src/compiler/evaluation/functions/filter.cc
+++ b/lib/src/compiler/evaluation/functions/filter.cc
@@ -151,17 +151,17 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                     context.name() %
                     arguments.size()
                 ).str(),
-                arguments.size() > 1 ? context.argument_context(1) : context.call_site()
+                arguments.size() > 1 ? context.argument_context(1) : context.name()
             );
         }
 
         // Check the lambda
         if (!context.lambda()) {
-            throw evaluation_exception((boost::format("expected a lambda to '%1%' function but one was not given.") % context.name()).str(), context.call_site());
+            throw evaluation_exception((boost::format("expected a lambda to '%1%' function but one was not given.") % context.name()).str(), context.name());
         }
         auto count = context.lambda()->parameters.size();
         if (count == 0 || count > 2) {
-            throw evaluation_exception((boost::format("expected 1 or 2 lambda parameters but %1% were given.") % count).str(), context.lambda()->context);
+            throw evaluation_exception((boost::format("expected 1 or 2 lambda parameters but %1% were specified.") % count).str(), *context.lambda());
         }
         return boost::apply_visitor(filter_visitor(context), arguments[0]);
     }

--- a/lib/src/compiler/evaluation/functions/inline_epp.cc
+++ b/lib/src/compiler/evaluation/functions/inline_epp.cc
@@ -18,7 +18,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         auto& arguments = context.arguments();
         auto count = arguments.size();
         if (count == 0 || count > 2) {
-            throw evaluation_exception((boost::format("expected 1 or 2 arguments to '%1%' function but %2% were given.") % context.name() % count).str(), count > 2 ? context.argument_context(2) : context.call_site());
+            throw evaluation_exception((boost::format("expected 1 or 2 arguments to '%1%' function but %2% were given.") % context.name() % count).str(), count > 2 ? context.argument_context(2) : context.name());
         }
         // First argument should be a string
         auto input = arguments[0]->as<string>();
@@ -63,8 +63,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
             // Log the underlying problem and then throw an error pointing at the argument
             size_t column;
             string text;
-            tie(text, column) = lexer::get_text_and_column(*input, ex.position().offset());
-            evaluation_context.node().logger().log(logging::level::error, ex.position().line(), column, text, path, ex.what());
+            auto& begin = ex.range().begin();
+            tie(text, column) = lexer::get_text_and_column(*input, begin.offset());
+            evaluation_context.node().logger().log(logging::level::error, begin.line(), column, ex.range().length(), text, path, ex.what());
             throw evaluation_exception("parsing of EPP template failed.", context.argument_context(0));
         } catch (argument_exception const& ex) {
             throw evaluation_exception((boost::format("EPP template argument error: %1%") % ex.what()).str(), context.argument_context(1));

--- a/lib/src/compiler/evaluation/functions/map.cc
+++ b/lib/src/compiler/evaluation/functions/map.cc
@@ -139,16 +139,16 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         auto& arguments = context.arguments();
         auto count = arguments.size();
         if (count != 1) {
-            throw evaluation_exception((boost::format("expected 1 argument to '%1%' function but %2% were given.") % context.name() % count).str(), count > 1 ? context.argument_context(1) : context.call_site());
+            throw evaluation_exception((boost::format("expected 1 argument to '%1%' function but %2% were given.") % context.name() % count).str(), count > 1 ? context.argument_context(1) : context.name());
         }
 
         // Check the lambda
         if (!context.lambda()) {
-            throw evaluation_exception((boost::format("expected a lambda to '%1%' function but one was not given.") % context.name()).str(), context.call_site());
+            throw evaluation_exception((boost::format("expected a lambda to '%1%' function but one was not given.") % context.name()).str(), context.name());
         }
         count = context.lambda()->parameters.size();
         if (count == 0 || count > 2) {
-            throw evaluation_exception((boost::format("expected 1 or 2 lambda parameters but %1% were given.") % count).str(), context.lambda()->context);
+            throw evaluation_exception((boost::format("expected 1 or 2 lambda parameters but %1% were specified.") % count).str(), *context.lambda());
         }
         return boost::apply_visitor(map_visitor(context), arguments[0]);
     }

--- a/lib/src/compiler/evaluation/functions/reduce.cc
+++ b/lib/src/compiler/evaluation/functions/reduce.cc
@@ -149,16 +149,16 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         auto& arguments = context.arguments();
         auto count = arguments.size();
         if (arguments.size() == 0 || arguments.size() > 2) {
-            throw evaluation_exception((boost::format("expected 1 or 2 arguments to '%1%' function but %2% were given.") % context.name() % count).str(), count > 2 ? context.argument_context(2) : context.call_site());
+            throw evaluation_exception((boost::format("expected 1 or 2 arguments to '%1%' function but %2% were given.") % context.name() % count).str(), count > 2 ? context.argument_context(2) : context.name());
         }
 
         // Check the lambda
         if (!context.lambda()) {
-            throw evaluation_exception((boost::format("expected a lambda to '%1%' function but one was not given.") % context.name()).str(), context.call_site());
+            throw evaluation_exception((boost::format("expected a lambda to '%1%' function but one was not given.") % context.name()).str(), context.name());
         }
         count = context.lambda()->parameters.size();
         if (count != 2) {
-            throw evaluation_exception((boost::format("expected 2 lambda parameters but %1% were given.") % count).str(), context.lambda()->context);
+            throw evaluation_exception((boost::format("expected 2 lambda parameters but %1% were specified.") % count).str(), *context.lambda());
         }
 
         // Use the provided memo if there is one

--- a/lib/src/compiler/evaluation/functions/split.cc
+++ b/lib/src/compiler/evaluation/functions/split.cc
@@ -95,7 +95,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         auto& arguments = context.arguments();
         auto count = arguments.size();
         if (count != 2) {
-            throw evaluation_exception((boost::format("expected 2 arguments to '%1%' function but %2% were given.") % context.name() % count).str(), count > 2 ? context.argument_context(2) : context.call_site());
+            throw evaluation_exception((boost::format("expected 2 arguments to '%1%' function but %2% were given.") % context.name() % count).str(), count > 2 ? context.argument_context(2) : context.name());
         }
         return boost::apply_visitor(split_visitor(context), arguments[0], arguments[1]);
     }

--- a/lib/src/compiler/evaluation/functions/tag.cc
+++ b/lib/src/compiler/evaluation/functions/tag.cc
@@ -15,13 +15,13 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         // Check the empty arguments count
         auto& arguments = context.arguments();
         if (arguments.empty()) {
-            throw evaluation_exception((boost::format("expected at least one argument to '%1%' function.") % context.name()).str(), context.call_site());
+            throw evaluation_exception((boost::format("expected at least one argument to '%1%' function.") % context.name()).str(), context.name());
         }
 
         // Get the current scope's resource
         auto resource = context.context().current_scope()->resource();
         if (!resource) {
-            throw evaluation_exception("the current scope has no associated resource and cannot be tagged.", context.call_site());
+            throw evaluation_exception("the current scope has no associated resource and cannot be tagged.", context.name());
         }
 
         // Add the tags to the resource

--- a/lib/src/compiler/evaluation/functions/tagged.cc
+++ b/lib/src/compiler/evaluation/functions/tagged.cc
@@ -15,7 +15,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         // Check the empty arguments count
         auto& arguments = context.arguments();
         if (arguments.empty()) {
-            throw evaluation_exception((boost::format("expected at least one argument to '%1%' function.") % context.name()).str(), context.call_site());
+            throw evaluation_exception((boost::format("expected at least one argument to '%1%' function.") % context.name()).str(), context.name());
         }
 
         // Get the current scope's resource

--- a/lib/src/compiler/evaluation/functions/versioncmp.cc
+++ b/lib/src/compiler/evaluation/functions/versioncmp.cc
@@ -15,7 +15,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         auto& arguments = context.arguments();
         auto count = arguments.size();
         if (count != 2) {
-            throw evaluation_exception((boost::format("expected 2 arguments to '%1%' function but %2% were given.") % context.name() % count).str(), count > 2 ? context.argument_context(2) : context.call_site());
+            throw evaluation_exception((boost::format("expected 2 arguments to '%1%' function but %2% were given.") % context.name() % count).str(), count > 2 ? context.argument_context(2) : context.name());
         }
 
         // Both arguments should be Strings

--- a/lib/src/compiler/evaluation/functions/with.cc
+++ b/lib/src/compiler/evaluation/functions/with.cc
@@ -11,7 +11,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
     value with::operator()(function_call_context& context) const
     {
         if (!context.lambda()) {
-            throw evaluation_exception((boost::format("expected a lambda to '%1%' function but one was not given.") % context.name()).str(), context.call_site());
+            throw evaluation_exception((boost::format("expected a lambda to '%1%' function but one was not given.") % context.name()).str(), context.name());
         }
 
         try {

--- a/lib/src/compiler/evaluation/operators/match.cc
+++ b/lib/src/compiler/evaluation/operators/match.cc
@@ -67,7 +67,6 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
 
     value match::operator()(binary_operator_context const& context) const
     {
-        match_visitor visitor(context);
         return boost::apply_visitor(match_visitor(context), context.left(), context.right());
     }
 

--- a/lib/src/compiler/evaluation/postfix_evaluator.cc
+++ b/lib/src/compiler/evaluation/postfix_evaluator.cc
@@ -18,7 +18,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             _evaluator(context)
         {
             _value = _evaluator.evaluate(expression.primary);
-            _value_context = expression.context();
+            _value_context = expression.primary.context();
             _splat = expression.is_splat();
 
             for (auto const& subexpression : expression.subexpressions) {
@@ -65,7 +65,7 @@ namespace puppet { namespace compiler { namespace evaluation {
 
             // Handle no matching case
             if (!default_index) {
-                throw evaluation_exception((boost::format("no matching selector case for value '%1%'.") % _value).str(), expression.context);
+                throw evaluation_exception((boost::format("no matching selector case for value '%1%'.") % _value).str(), expression);
             }
 
             // Evaluate the default case
@@ -78,14 +78,14 @@ namespace puppet { namespace compiler { namespace evaluation {
         {
             access_evaluator evaluator(_evaluator.context());
             _value = evaluator.evaluate(_value, expression);
-            _value_context = expression.context;
+            _value_context = expression;
         }
 
         void operator()(method_call_expression const& expression)
         {
             functions::function_call_context context { _evaluator.context(), expression, _value, _value_context, _splat };
             _value = _evaluator.context().dispatcher().dispatch(context);
-            _value_context = expression.context;
+            _value_context = expression.context();
         }
 
         value& result()

--- a/lib/src/compiler/evaluation/scope.cc
+++ b/lib/src/compiler/evaluation/scope.cc
@@ -11,7 +11,7 @@ namespace puppet { namespace compiler { namespace evaluation {
     {
         if (context) {
             _path = context->tree->shared_path();
-            _line = context->position.line();
+            _line = context->begin.line();
         }
     }
 

--- a/lib/src/compiler/lexer/number_token.cc
+++ b/lib/src/compiler/lexer/number_token.cc
@@ -6,29 +6,23 @@ using namespace std;
 
 namespace puppet { namespace compiler { namespace lexer {
 
-    number_token::number_token() :
-        _base(numeric_base::decimal)
-    {
-    }
-
-
-    number_token::number_token(lexer::position position, int64_t value, numeric_base base) :
-        _position(rvalue_cast(position)),
+    number_token::number_token(lexer::range range, int64_t value, numeric_base base) :
+        _range(rvalue_cast(range)),
         _value(value),
         _base(base)
     {
     }
 
-    number_token::number_token(lexer::position position, double value) :
-        _position(rvalue_cast(position)),
+    number_token::number_token(lexer::range range, double value) :
+        _range(rvalue_cast(range)),
         _value(value),
         _base(numeric_base::decimal)
     {
     }
 
-    lexer::position const& number_token::position() const
+    lexer::range const& number_token::range() const
     {
-        return _position;
+        return _range;
     }
 
     number_token::value_type const& number_token::value() const

--- a/lib/src/compiler/lexer/position.cc
+++ b/lib/src/compiler/lexer/position.cc
@@ -1,4 +1,5 @@
 #include <puppet/compiler/lexer/position.hpp>
+#include <puppet/cast.hpp>
 
 using namespace std;
 
@@ -33,6 +34,43 @@ namespace puppet { namespace compiler { namespace lexer {
         }
 
         ++_offset;
+    }
+
+    range::range(position begin, position end) :
+        _begin(rvalue_cast(begin)),
+        _end(rvalue_cast(end))
+    {
+    }
+
+    range::range(position begin, size_t length) :
+        _begin(rvalue_cast(begin))
+    {
+        _end = position{ _begin.offset() + length, _begin.line() };
+    }
+
+    position const& range::begin() const
+    {
+        return _begin;
+    }
+
+    void range::begin(position begin)
+    {
+        _begin = rvalue_cast(begin);
+    }
+
+    position const& range::end() const
+    {
+        return _end;
+    }
+
+    void range::end(position end)
+    {
+        _end = rvalue_cast(end);
+    }
+
+    size_t range::length() const
+    {
+        return _end.offset() - _begin.offset();
     }
 
     ostream& operator<<(ostream& os, lexer::position const& position)

--- a/lib/src/compiler/registry.cc
+++ b/lib/src/compiler/registry.cc
@@ -14,7 +14,7 @@ namespace puppet { namespace compiler {
 
     klass::klass(string name, ast::class_expression const& expression) :
         _name(rvalue_cast(name)),
-        _tree(expression.context.tree->shared_from_this()),
+        _tree(expression.tree->shared_from_this()),
         _expression(expression)
     {
     }
@@ -52,13 +52,13 @@ namespace puppet { namespace compiler {
             return context.node_or_top();
         }
 
-        context.declare_class(parent->value, parent->context);
+        context.declare_class(parent->value, *parent);
         return context.find_scope(parent->value);
     }
 
     defined_type::defined_type(string name, ast::defined_type_expression const& expression) :
         _name(rvalue_cast(name)),
-        _tree(expression.context.tree->shared_from_this()),
+        _tree(expression.tree->shared_from_this()),
         _expression(expression)
     {
     }
@@ -86,7 +86,7 @@ namespace puppet { namespace compiler {
     }
 
     node_definition::node_definition(ast::node_expression const& expression) :
-        _tree(expression.context.tree->shared_from_this()),
+        _tree(expression.tree->shared_from_this()),
         _expression(expression)
     {
     }

--- a/lib/src/runtime/values/type.cc
+++ b/lib/src/runtime/values/type.cc
@@ -63,7 +63,7 @@ namespace puppet { namespace runtime { namespace values {
         return boost::apply_visitor(is_specialization_visitor(type), _value);
     }
 
-    type type::parse(evaluation::context& context, string const& expression)
+    boost::optional<type> type::parse(evaluation::context& context, string const& expression)
     {
         try {
             auto ast = parser::parse_string(expression);
@@ -77,7 +77,7 @@ namespace puppet { namespace runtime { namespace values {
         } catch (parse_exception const&) {
         } catch (evaluation_exception const&) {
         }
-        throw parse_exception((boost::format("the expression '%1%' is not a valid type specification.") % expression).str(), compiler::lexer::position(0, 1));
+        return boost::none;
     }
 
     bool operator==(type const& left, type const& right)

--- a/lib/tests/lexer/lexer.cc
+++ b/lib/tests/lexer/lexer.cc
@@ -16,6 +16,12 @@ struct token_value_visitor : boost::static_visitor<string>
         return os.str();
     }
 
+    template <typename Iterator>
+    result_type operator()(string_token<Iterator> const& token) const
+    {
+        return string(token.value().begin(), token.value().end());
+    }
+
     template <typename T>
     result_type operator()(T const& token) const
     {
@@ -61,8 +67,7 @@ void require_string_token(
 
     auto value = boost::get<string_token<typename Iterator::value_type::iterator_type>>(&token->value());
     REQUIRE(value);
-    string text(value->begin(), value->end());
-    REQUIRE(text == expected_value);
+    REQUIRE(value->value() == expected_value);
     REQUIRE(value->escapes() == expected_escapes);
     REQUIRE(value->quote() == expected_quote);
     REQUIRE(value->interpolated() == expected_interpolated);


### PR DESCRIPTION
This refactoring updates the lexer, AST, and parser to annotate the AST with
needed range information.  This will be needed for AST serialization in the
future, but it also immediately provides for "highlighting" of the error in
error messages (using a "^~~~" squiggle).

The context parser has been replaced with two parsers: begin and end.  The
former parses the beginning position of a token and the latter parses the
ending position of a token.  This allows the rules to populate needed position
information depending on rule specific logic.

This also fixes string interpolation of heredocs not populating the right
context on errors. Previously the start of the string token (the @ for heredocs)
was used as the start of the string's value, but this was incorrect.  The lexer
now properly records the range of the string value itself so that the context
can be calculated from where the string's value starts and not where the token
starts.

Closes GH #98.