### PR TITLE
Enable code coverage collection with codecov.io.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,16 @@ services:
 before_install:
   - docker pull peterhuene/puppetcpp
 script:
-  - docker run -v `pwd`:/puppetcpp peterhuene/puppetcpp /bin/sh -c "cd /puppetcpp && cmake . && make -j 2 && bin/puppetcpp --help && ctest -V"
+  - >
+    docker run -v `pwd`:/puppetcpp peterhuene/puppetcpp /bin/sh -c "
+    cd /puppetcpp &&
+    cmake . -DTEST_COVERAGE=$TEST_COVERAGE -DCMAKE_BUILD_TYPE=$BUILD &&
+    make -j 2 &&
+    bin/puppetcpp --help &&
+    ctest -V &&
+    CI=true TRAVIS=true TRAVIS_BRANCH=$TRAVIS_BRANCH TRAVIS_COMMIT=$TRAVIS_COMMIT TRAVIS_JOB_NUMBER=$TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST TRAVIS_JOB_ID=$TRAVIS_JOB_ID TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG $COVERAGE_TOOL
+    "
+env:
+  matrix:
+    - BUILD=RELEASE TEST_COVERAGE=OFF COVERAGE_TOOL=true
+    - BUILD=DEBUG   TEST_COVERAGE=ON  COVERAGE_TOOL=/root/.local/bin/codecov

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ enable_testing()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -ftemplate-depth=512 -Wall -Wextra -Werror -Wno-unused-parameter")
 
+if (${TEST_COVERAGE})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -coverage")
+endif()
+
 # Set RPATH if not installing to a system library directory
 list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" INSTALL_IS_SYSTEM_DIR)
 if ("${INSTALL_IS_SYSTEM_DIR}" STREQUAL "-1")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM l3iggs/archlinux
 MAINTAINER Peter Huene <peterhuene@gmail.com>
-RUN pacman -Sy --noconfirm gcc git make cmake boost yaml-cpp && \
+RUN pacman -Sy --noconfirm gcc git make cmake boost yaml-cpp python-pip && \
     yes | pacman -Scc && \
+    pip install --user codecov && \
     git clone --recursive https://github.com/puppetlabs/facter.git /tmp/facter && \
     pushd /tmp/facter && \
     cmake . && \
@@ -9,4 +10,3 @@ RUN pacman -Sy --noconfirm gcc git make cmake boost yaml-cpp && \
     make install && \
     popd && \
     rm -rf /tmp/facter
-


### PR DESCRIPTION
Modify the build to optionally pass -coverage to the compiler.

Modify the Docker image to install the codecov utility.

Modify travis to use the codecov utility to upload the coverage data.

Add a debug and release build to the Travis matrix.