### PR TITLE
Update to Onigmo 6.0+.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Build Requirements
 * [CMake](https://cmake.org/) >= 3.0
 * [Boost Libraries](http://www.boost.org/) >= 1.60.0
 * [ICU](http://site.icu-project.org/) >= 57.1
-* [Onigmo](https://github.com/k-takata/Onigmo) >= 5.15.0 (build with `--enable-multithread`)
+* [Onigmo](https://github.com/k-takata/Onigmo) >= 6.0.0
 * [Facter](https://github.com/puppetlabs/facter) >= 3.0
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp) >= 0.5.1
 * [Editline](http://thrysoee.dk/editline/) (optional - improves the REPL experience)

--- a/cmake/FindOnigmo.cmake
+++ b/cmake/FindOnigmo.cmake
@@ -1,6 +1,6 @@
 include(FindDependency)
 
-find_dependency(Onigmo DISPLAY "Onigmo" HEADERS "oniguruma.h" LIBRARIES libonig.so libonig.dylib libonig.dll)
+find_dependency(Onigmo DISPLAY "Onigmo" HEADERS "onigmo.h" LIBRARIES libonigmo.so libonigmo.dylib libonigmo.dll)
 
 include(FeatureSummary)
 set_package_properties(Onigmo PROPERTIES DESCRIPTION "A regular expressions library, used in current Ruby versions, that was forked from Oniguruma" URL "https://github.com/k-takata/Onigmo")

--- a/docker/puppetcpp-ci/Dockerfile
+++ b/docker/puppetcpp-ci/Dockerfile
@@ -1,10 +1,11 @@
 FROM gliderlabs/alpine:edge
 MAINTAINER Peter Huene <peterhuene@gmail.com>
-RUN apk add --no-cache make cmake gcc g++ boost-dev boost-program_options curl-dev libedit-dev git py-pip icu-dev && \
+RUN apk add --no-cache make cmake gcc g++ boost-dev boost-program_options curl-dev libedit-dev git py-pip icu-dev openssl && \
+    wget https://raw.githubusercontent.com/peterhuene/spirit/fcf705ef9ea316dded54e14fb6ba9d01a27ec0e4/include/boost/spirit/home/x3/operator/detail/sequence.hpp -O /usr/include/boost/spirit/home/x3/operator/detail/sequence.hpp && \
     pip install --user codecov && \
     git clone https://github.com/k-takata/Onigmo.git /tmp/onigmo && \
     cd /tmp/onigmo && \
-    ./configure --enable-shared --enable-multithread && \
+    ./configure --enable-shared && \
     make -j 4 && \
     make install && \
     cd && \
@@ -23,6 +24,13 @@ RUN apk add --no-cache make cmake gcc g++ boost-dev boost-program_options curl-d
     make install && \
     cd && \
     rm -rf /tmp/leatherman && \
+    git clone --recursive https://github.com/puppetlabs/cpp-hocon.git /tmp/cpp-hocon && \
+    cd /tmp/cpp-hocon && \
+    cmake . && \
+    make -j 4 && \
+    make install && \
+    cd && \
+    rm -rf /tmp/cpp-hocon && \
     git clone --recursive https://github.com/puppetlabs/facter.git /tmp/facter && \
     cd /tmp/facter && \
     cmake . && \

--- a/docker/puppetcpp/Dockerfile
+++ b/docker/puppetcpp/Dockerfile
@@ -1,9 +1,10 @@
 FROM gliderlabs/alpine:edge
 MAINTAINER Peter Huene <peterhuene@gmail.com>
-RUN apk add --no-cache make cmake gcc g++ boost-dev curl-dev libedit-dev git icu-dev && \
+RUN apk add --no-cache make cmake gcc g++ boost-dev curl-dev libedit-dev git icu-dev openssl && \
+    wget https://raw.githubusercontent.com/peterhuene/spirit/fcf705ef9ea316dded54e14fb6ba9d01a27ec0e4/include/boost/spirit/home/x3/operator/detail/sequence.hpp -O /usr/include/boost/spirit/home/x3/operator/detail/sequence.hpp && \
     git clone https://github.com/k-takata/Onigmo.git /tmp/onigmo && \
     cd /tmp/onigmo && \
-    ./configure --enable-shared --enable-multithread && \
+    ./configure --enable-shared && \
     make -j 4 && \
     make install && \
     cd && \
@@ -22,6 +23,13 @@ RUN apk add --no-cache make cmake gcc g++ boost-dev curl-dev libedit-dev git icu
     make install && \
     cd && \
     rm -rf /tmp/leatherman && \
+    git clone --recursive https://github.com/puppetlabs/cpp-hocon.git /tmp/cpp-hocon && \
+    cd /tmp/cpp-hocon && \
+    cmake . && \
+    make -j 4 && \
+    make install && \
+    cd && \
+    rm -rf /tmp/cpp-hocon && \
     git clone --recursive https://github.com/puppetlabs/facter.git /tmp/facter && \
     cd /tmp/facter && \
     cmake . && \
@@ -29,7 +37,7 @@ RUN apk add --no-cache make cmake gcc g++ boost-dev curl-dev libedit-dev git icu
     make install && \
     cd && \
     rm -rf /tmp/facter && \
-    git clone --recursive https://github.com/peterhuene/puppetcpp.git -b docker /tmp/puppetcpp && \
+    git clone --recursive https://github.com/peterhuene/puppetcpp.git /tmp/puppetcpp && \
     cd /tmp/puppetcpp && \
     cmake . && \
     make -j 4 && \
@@ -37,6 +45,6 @@ RUN apk add --no-cache make cmake gcc g++ boost-dev curl-dev libedit-dev git icu
     cd && \
     rm -rf /tmp/puppetcpp && \
     mkdir -p /etc/puppetlabs/code/environments/production && \
-    apk --no-cache del make cmake gcc g++ boost-dev curl-dev libedit-dev git icu-dev && \
+    apk --no-cache del make cmake gcc g++ boost-dev curl-dev libedit-dev git icu-dev openssl && \
     apk --no-cache add libstdc++ boost boost-program_options libcurl libedit icu-libs
 ENTRYPOINT ["/usr/local/bin/puppetcpp"]

--- a/exe/main.cc
+++ b/exe/main.cc
@@ -5,7 +5,7 @@
 #include <puppet/options/commands/repl.hpp>
 #include <puppet/options/commands/version.hpp>
 #include <puppet/logging/logger.hpp>
-#include <oniguruma.h>
+#include <onigmo.h>
 
 using namespace std;
 using namespace puppet;

--- a/lib/include/puppet/utility/regex.hpp
+++ b/lib/include/puppet/utility/regex.hpp
@@ -7,10 +7,11 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/optional.hpp>
-#include <oniguruma.h>
+#include <onigmo.h>
 #include <vector>
 #include <string>
 #include <exception>
+#include <memory>
 
 namespace puppet { namespace utility {
 

--- a/lib/src/utility/regex.cc
+++ b/lib/src/utility/regex.cc
@@ -114,7 +114,7 @@ namespace puppet { namespace utility {
             reinterpret_cast<OnigUChar const*>(expression.data() + expression.size()),
             ONIG_OPTION_DEFAULT,
             ONIG_ENCODING_UTF8,
-            ONIG_SYNTAX_RUBY,
+            const_cast<OnigSyntaxType*>(ONIG_SYNTAX_RUBY),
             &error_info
         );
         if (result != ONIG_NORMAL) {


### PR DESCRIPTION
This commit updates the dependency on Onigmo to 6.0 or later.

Fixes the source to conform to 6.0+ changes: namely that the header and
libraries have been renamed.